### PR TITLE
Refactor module visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Run clippy check
-        run: cargo clippy -- -W clippy::pedantic
+        run: cargo clippy -- -W clippy::pedantic -D warnings
 
   docs-build:
     name: Docs build

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,13 +4,13 @@ use crate::models::ListKeysRequest;
 use crate::models::ListKeysResponse;
 use crate::models::VerifyKeyRequest;
 use crate::models::VerifyKeyResponse;
+use crate::models::Wrapped;
 use crate::services::ApiService;
 use crate::services::HttpService;
 use crate::services::KeyService;
-use crate::types::Response;
 
 #[allow(unused_imports)]
-use crate::types::HttpError;
+use crate::models::HttpError;
 
 /// The client used to make requests to the unkey api.
 #[derive(Debug, Clone)]
@@ -109,24 +109,24 @@ impl Client {
     /// - `req`: The verify key request to send.
     ///
     /// # Returns
-    /// A result containing the response, or an [`HttpError`].
+    /// A wrapper containing the response, or an [`HttpError`].
     ///
     /// # Example
     /// ```no_run
     /// # async fn verify() {
     /// # use unkey_sdk::Client;
     /// # use unkey_sdk::models::VerifyKeyRequest;
-    /// # use unkey_sdk::types::Response;
+    /// # use unkey_sdk::models::Wrapped;
     /// let c = Client::new("abc123");
     /// let req = VerifyKeyRequest::new("test_KEYABC");
     ///
     /// match c.verify_key(req).await {
-    ///     Response::Ok(res) => println!("{:?}", res),
-    ///     Response::Err(err) => println!("{:?}", err),
+    ///     Wrapped::Ok(res) => println!("{:?}", res),
+    ///     Wrapped::Err(err) => println!("{:?}", err),
     /// }
     /// # }
     /// ```
-    pub async fn verify_key(&self, req: VerifyKeyRequest) -> Response<VerifyKeyResponse> {
+    pub async fn verify_key(&self, req: VerifyKeyRequest) -> Wrapped<VerifyKeyResponse> {
         self.keys.verify_key(&self.http, req).await
     }
 
@@ -136,24 +136,24 @@ impl Client {
     /// - `req`: The create key request to send.
     ///
     /// # Returns
-    /// A result containing the response, or an [`HttpError`].
+    /// A wrapper containing the response, or an [`HttpError`].
     ///
     /// # Example
     /// ```no_run
     /// # async fn create() {
     /// # use unkey_sdk::Client;
     /// # use unkey_sdk::models::CreateKeyRequest;
-    /// # use unkey_sdk::types::Response;
+    /// # use unkey_sdk::models::Wrapped;
     /// let c = Client::new("abc123");
     /// let req = CreateKeyRequest::new("api_CCC").set_remaining(100);
     ///
     /// match c.create_key(req).await {
-    ///     Response::Ok(res) => println!("{:?}", res),
-    ///     Response::Err(err) => println!("{:?}", err),
+    ///     Wrapped::Ok(res) => println!("{:?}", res),
+    ///     Wrapped::Err(err) => println!("{:?}", err),
     /// }
     /// # }
     /// ```
-    pub async fn create_key(&self, req: CreateKeyRequest) -> Response<CreateKeyResponse> {
+    pub async fn create_key(&self, req: CreateKeyRequest) -> Wrapped<CreateKeyResponse> {
         self.keys.create_key(&self.http, req).await
     }
 
@@ -163,24 +163,24 @@ impl Client {
     /// - `req`: The list keys request to send.
     ///
     /// # Returns
-    /// A result containing the response, or an [`HttpError`].
+    /// A wrapper containing the response, or an [`HttpError`].
     ///
     /// # Example
     /// ```no_run
     /// # async fn list() {
     /// # use unkey_sdk::Client;
     /// # use unkey_sdk::models::ListKeysRequest;
-    /// # use unkey_sdk::types::Response;
+    /// # use unkey_sdk::models::Wrapped;
     /// let c = Client::new("abc123");
     /// let req = ListKeysRequest::new("api_id").set_limit(25);
     ///
     /// match c.list_keys(req).await {
-    ///     Response::Ok(res) => println!("{:?}", res),
-    ///     Response::Err(err) => println!("{:?}", err),
+    ///     Wrapped::Ok(res) => println!("{:?}", res),
+    ///     Wrapped::Err(err) => println!("{:?}", err),
     /// }
     /// # }
     /// ```
-    pub async fn list_keys(&self, req: ListKeysRequest) -> Response<ListKeysResponse> {
+    pub async fn list_keys(&self, req: ListKeysRequest) -> Wrapped<ListKeysResponse> {
         self.apis.list_keys(&self.http, req).await
     }
 }

--- a/src/models/http.rs
+++ b/src/models/http.rs
@@ -34,6 +34,7 @@ pub enum ErrorCode {
 }
 
 /// An http error representation.
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Deserialize)]
 pub struct HttpError {
     /// The error code for the error.
@@ -55,22 +56,25 @@ impl HttpError {
     ///
     /// # Example
     /// ```
-    /// # use unkey_sdk::types::HttpError;
-    /// # use unkey_sdk::types::ErrorCode;
-    /// let e = HttpError::new(ErrorCode::Unknown, String::from("err"));
+    /// # use unkey_sdk::models::HttpError;
+    /// # use unkey_sdk::models::ErrorCode;
+    /// let e = HttpError {
+    ///     code: ErrorCode::Unknown,
+    ///     message: String::from("err")
+    /// };
     ///
     /// assert_eq!(e.code, ErrorCode::Unknown);
     /// assert_eq!(e.message, String::from("err"));
     /// ```
     #[must_use]
-    pub fn new(code: ErrorCode, message: String) -> Self {
+    pub(crate) fn new(code: ErrorCode, message: String) -> Self {
         Self { code, message }
     }
 }
 
-/// A generic response type the client returns.
+/// A wrapper around the response type or an error.
 #[derive(Deserialize, Debug, Clone)]
-pub enum Response<T> {
+pub enum Wrapped<T> {
     /// The error value.
     #[serde(rename = "error")]
     Err(HttpError),

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,7 +1,9 @@
 mod apis;
+mod http;
 mod keys;
 mod ratelimit;
 
 pub use apis::*;
+pub use http::*;
 pub use keys::*;
 pub use ratelimit::*;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -5,24 +5,27 @@ use reqwest::Method;
 ////////////////////////////////////////////////////////////////////////////////
 
 /// The create key endpoint `POST /keys`
-pub static CREATE_KEY: Route = Route::new(Method::POST, "/keys");
+pub(crate) static CREATE_KEY: Route = Route::new(Method::POST, "/keys");
 
 /// The verify key endpoint `POST /keys/verify`
-pub static VERIFY_KEY: Route = Route::new(Method::POST, "/keys/verify");
+pub(crate) static VERIFY_KEY: Route = Route::new(Method::POST, "/keys/verify");
 
 /// The delete key endpoint `DELETE /keys/{id}`
-pub static DELETE_KEY: Route = Route::new(Method::DELETE, "/keys/{}");
+#[allow(unused)] // Temporary until we implement this method
+pub(crate) static DELETE_KEY: Route = Route::new(Method::DELETE, "/keys/{}");
 
 /// The update key endpoint `PUT /keys/{id}`
-pub static UPDATE_KEY: Route = Route::new(Method::PUT, "/keys/{}");
+#[allow(unused)] // Temporary until we implement this method
+pub(crate) static UPDATE_KEY: Route = Route::new(Method::PUT, "/keys/{}");
 
 ////////////////////////////////////////////////////////////////////////////////
 
 /// The get api endpoint `GET /apis/{id}`
-pub static GET_API: Route = Route::new(Method::GET, "/apis/{}");
+#[allow(unused)] // Temporary until we implement this method
+pub(crate) static GET_API: Route = Route::new(Method::GET, "/apis/{}");
 
 /// The list keys endpoint `GET /apis/{id}/keys`
-pub static LIST_KEYS: Route = Route::new(Method::GET, "/apis/{}/keys");
+pub(crate) static LIST_KEYS: Route = Route::new(Method::GET, "/apis/{}/keys");
 
 ////////////////////////////////////////////////////////////////////////////////
 // END ROUTES
@@ -30,7 +33,7 @@ pub static LIST_KEYS: Route = Route::new(Method::GET, "/apis/{}/keys");
 
 /// A static route mapping to an unkey api endpoint.
 #[derive(Debug, Clone)]
-pub struct Route {
+pub(crate) struct Route {
     /// The http method for the route.
     pub method: Method,
 
@@ -50,16 +53,6 @@ impl Route {
     ///
     /// # Returns
     /// The new route.
-    ///
-    /// # Example
-    /// ```
-    /// # use unkey_sdk::routes::Route;
-    /// # use reqwest::Method;
-    /// let r = Route::new(Method::GET, "/keys/owo");
-    ///
-    /// assert_eq!(r.method, Method::GET);
-    /// assert_eq!(r.uri, "/keys/owo");
-    /// ```
     #[must_use]
     pub const fn new(method: Method, uri: &'static str) -> Self {
         Self { method, uri }
@@ -69,17 +62,6 @@ impl Route {
     ///
     /// # Returns
     /// The compiled route.
-    ///
-    /// # Example
-    /// ```
-    /// # use unkey_sdk::routes::Route;
-    /// # use reqwest::Method;
-    /// let r = Route::new(Method::GET, "/apis/woot").compile();
-    ///
-    /// assert_eq!(r.params, vec![]);
-    /// assert_eq!(r.method, Method::GET);
-    /// assert_eq!(r.uri, String::from("/apis/woot"));
-    /// ```
     #[must_use]
     pub fn compile(&self) -> CompiledRoute {
         CompiledRoute::new(self)
@@ -88,7 +70,7 @@ impl Route {
 
 /// A dynamic route that can be used directly for an outgoing request.
 #[derive(Debug, Clone)]
-pub struct CompiledRoute {
+pub(crate) struct CompiledRoute {
     /// The routes uri.
     pub uri: String,
 
@@ -107,19 +89,6 @@ impl CompiledRoute {
     ///
     /// # Returns
     /// Self The new route.
-    ///
-    /// # Example
-    /// ```
-    /// # use unkey_sdk::routes::CompiledRoute;
-    /// # use unkey_sdk::routes::Route;
-    /// # use reqwest::Method;
-    /// let r = Route::new(Method::GET, "/apis/hi");
-    /// let c = CompiledRoute::new(&r);
-    ///
-    /// assert_eq!(c.params, vec![]);
-    /// assert_eq!(c.method, Method::GET);
-    /// assert_eq!(c.uri, String::from("/apis/hi"));
-    /// ```
     #[must_use]
     #[rustfmt::skip]
     pub fn new(route: &Route) -> Self {
@@ -137,20 +106,6 @@ impl CompiledRoute {
     ///
     /// # Returns
     /// Self for chained calls.
-    ///
-    /// # Example
-    /// ```
-    /// # use unkey_sdk::routes::CompiledRoute;
-    /// # use unkey_sdk::routes::Route;
-    /// # use reqwest::Method;
-    /// let r = Route::new(Method::GET, "/apis/{}/keys/{}");
-    /// let mut c = CompiledRoute::new(&r);
-    /// c.uri_insert("5").uri_insert("1");
-    ///
-    /// assert_eq!(c.params, vec![]);
-    /// assert_eq!(c.method, Method::GET);
-    /// assert_eq!(c.uri, String::from("/apis/5/keys/1"));
-    /// ```
     pub fn uri_insert<T: Into<String>>(&mut self, param: T) -> &mut Self {
         self.uri = self.uri.replacen("{}", &param.into(), 1);
         self
@@ -164,20 +119,6 @@ impl CompiledRoute {
     ///
     /// # Returns
     /// Self for chained calls.
-    ///
-    /// # Example
-    /// ```
-    /// # use unkey_sdk::routes::CompiledRoute;
-    /// # use unkey_sdk::routes::Route;
-    /// # use reqwest::Method;
-    /// let r = Route::new(Method::GET, "/apis/milk");
-    /// let mut c = CompiledRoute::new(&r);
-    /// c.query_insert("test", "value");
-    ///
-    /// assert_eq!(c.params, vec![(String::from("test"), String::from("value"))]);
-    /// assert_eq!(c.method, Method::GET);
-    /// assert_eq!(c.uri, String::from("/apis/milk"));
-    /// ```
     pub fn query_insert<T: Into<String>>(&mut self, name: T, value: T) -> &mut Self {
         self.params.push((name.into(), value.into()));
         self
@@ -187,18 +128,6 @@ impl CompiledRoute {
     ///
     /// # Returns
     /// The formatted query string.
-    ///
-    /// # Example
-    /// ```
-    /// # use unkey_sdk::routes::CompiledRoute;
-    /// # use unkey_sdk::routes::Route;
-    /// # use reqwest::Method;
-    /// let r = Route::new(Method::GET, "/apis/milk");
-    /// let mut c = CompiledRoute::new(&r);
-    /// c.query_insert("test", "value").query_insert("js", "bad");
-    ///
-    /// assert_eq!(c.build_query(), String::from("?test=value&js=bad"));
-    /// ```
     #[must_use]
     pub fn build_query(&self) -> String {
         let mut query = self
@@ -213,5 +142,73 @@ impl CompiledRoute {
         }
 
         query
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::routes::CompiledRoute;
+    use crate::routes::Route;
+    use reqwest::Method;
+
+    #[test]
+    fn route_new() {
+        let r = Route::new(Method::GET, "/keys/owo");
+
+        assert_eq!(r.method, Method::GET);
+        assert_eq!(r.uri, "/keys/owo");
+    }
+
+    #[test]
+    fn route_compile() {
+        let r = Route::new(Method::GET, "/apis/woot").compile();
+
+        assert_eq!(r.params, vec![]);
+        assert_eq!(r.method, Method::GET);
+        assert_eq!(r.uri, String::from("/apis/woot"));
+    }
+
+    #[test]
+    fn compiled_route_new() {
+        let r = Route::new(Method::GET, "/apis/hi");
+        let c = CompiledRoute::new(&r);
+
+        assert_eq!(c.params, vec![]);
+        assert_eq!(c.method, Method::GET);
+        assert_eq!(c.uri, String::from("/apis/hi"));
+    }
+
+    #[test]
+    fn compiled_route_uri_insert() {
+        let r = Route::new(Method::GET, "/apis/{}/keys/{}");
+        let mut c = CompiledRoute::new(&r);
+        c.uri_insert("5").uri_insert("1");
+
+        assert_eq!(c.params, vec![]);
+        assert_eq!(c.method, Method::GET);
+        assert_eq!(c.uri, String::from("/apis/5/keys/1"));
+    }
+
+    #[test]
+    fn compiled_route_query_insert() {
+        let r = Route::new(Method::GET, "/apis/milk");
+        let mut c = CompiledRoute::new(&r);
+        c.query_insert("test", "value");
+
+        assert_eq!(c.method, Method::GET);
+        assert_eq!(c.uri, String::from("/apis/milk"));
+        assert_eq!(
+            c.params,
+            vec![(String::from("test"), String::from("value"))]
+        );
+    }
+
+    #[test]
+    fn compiled_route_build_query() {
+        let r = Route::new(Method::GET, "/apis/milk");
+        let mut c = CompiledRoute::new(&r);
+        c.query_insert("test", "value").query_insert("js", "bad");
+
+        assert_eq!(c.build_query(), String::from("?test=value&js=bad"));
     }
 }

--- a/src/services/apis.rs
+++ b/src/services/apis.rs
@@ -3,15 +3,15 @@ use crate::unwind_response;
 
 use crate::models::ListKeysRequest;
 use crate::models::ListKeysResponse;
+use crate::models::Wrapped;
 use crate::services::HttpService;
-use crate::types::Response;
 
 #[allow(unused_imports)]
-use crate::types::HttpError;
+use crate::models::HttpError;
 
 /// The service that handles api related requests.
 #[derive(Debug, Clone)]
-pub struct ApiService;
+pub(crate) struct ApiService;
 
 impl ApiService {
     /// Retrieves a paginated list of keys for an api.
@@ -21,12 +21,12 @@ impl ApiService {
     /// - `req`: The request to send.
     ///
     /// # Returns
-    /// A result containing the response, or an [`HttpError`].
+    /// A wrapper around the response, or an [`HttpError`].
     pub async fn list_keys(
         &self,
         http: &HttpService,
         req: ListKeysRequest,
-    ) -> Response<ListKeysResponse> {
+    ) -> Wrapped<ListKeysResponse> {
         let mut route = routes::LIST_KEYS.compile();
         route
             .uri_insert(&req.api_id)

--- a/src/services/http.rs
+++ b/src/services/http.rs
@@ -2,8 +2,8 @@ use reqwest::header::{HeaderMap, HeaderValue};
 use serde::Serialize;
 
 use crate::logging;
+use crate::models::HttpResult;
 use crate::routes::CompiledRoute;
-use crate::types::HttpResult;
 
 // TODO: implement versioning at some point
 /// The unkey api production base url.
@@ -12,7 +12,7 @@ static BASE_API_URL: &str = "https://api.unkey.dev/v1";
 /// The http service used for handling requests.
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone)]
-pub struct HttpService {
+pub(crate) struct HttpService {
     /// The base url to use for requests.
     url: String,
 
@@ -31,12 +31,6 @@ impl HttpService {
     ///
     /// # Returns
     /// The new http service.
-    ///
-    /// # Example
-    /// ```
-    /// # use unkey_sdk::services::HttpService;
-    /// let s = HttpService::new("unkey_abds");
-    /// ```
     #[must_use]
     #[rustfmt::skip]
     pub fn new(key: &str) -> Self {
@@ -56,12 +50,6 @@ impl HttpService {
     ///
     /// # Returns
     /// The new http service.
-    ///
-    /// # Example
-    /// ```
-    /// # use unkey_sdk::services::HttpService;
-    /// let s = HttpService::with_url("unkey_abds", "http://localhost:3000");
-    /// ```
     #[must_use]
     #[rustfmt::skip]
     pub fn with_url(key: &str, url: &str) -> Self {
@@ -108,13 +96,6 @@ impl HttpService {
     ///
     /// # Arguments
     /// - `key`: The new root api key to use.
-    ///
-    /// # Example
-    /// ```
-    /// # use unkey_sdk::services::HttpService;
-    /// let mut s = HttpService::new("unkey_ghj");
-    /// s.set_key("unkey_abc");
-    /// ```
     pub fn set_key(&mut self, key: &str) {
         let header = HeaderValue::from_str(key);
 
@@ -130,13 +111,6 @@ impl HttpService {
     ///
     /// # Arguments
     /// - `url`: The new api base url to use.
-    ///
-    /// # Example
-    /// ```
-    /// # use unkey_sdk::services::HttpService;
-    /// let mut s = HttpService::new("unkey_ghj");
-    /// s.set_url("http://localhost:4000");
-    /// ```
     pub fn set_url(&mut self, url: &str) {
         self.url = url.to_string();
     }
@@ -152,22 +126,6 @@ impl HttpService {
     ///
     /// # Errors
     /// The reqwest error encountered during the request.
-    ///
-    /// # Example
-    /// ```no_run
-    /// # use unkey_sdk::services::HttpService;
-    /// # use unkey_sdk::routes::Route;
-    /// # use unkey_sdk::routes::CompiledRoute;
-    /// # use unkey_sdk::models::CreateKeyRequest;
-    /// # use reqwest::Method;
-    /// # async fn f() {
-    /// let r = Route::new(Method::GET, "/death/destroyer/worlds");
-    /// let c = CompiledRoute::new(&r);
-    /// let s = HttpService::new("unkey_ghj");
-    ///
-    /// let res = s.fetch::<CreateKeyRequest>(c, None).await;
-    /// # }
-    /// ```
     pub async fn fetch<T>(&self, route: CompiledRoute, payload: Option<T>) -> HttpResult
     where
         T: std::fmt::Debug + Serialize,

--- a/src/services/keys.rs
+++ b/src/services/keys.rs
@@ -5,15 +5,15 @@ use crate::models::CreateKeyRequest;
 use crate::models::CreateKeyResponse;
 use crate::models::VerifyKeyRequest;
 use crate::models::VerifyKeyResponse;
+use crate::models::Wrapped;
 use crate::services::HttpService;
-use crate::types::Response;
 
 #[allow(unused_imports)]
-use crate::types::HttpError;
+use crate::models::HttpError;
 
 /// The service that handles key related requests.
 #[derive(Debug, Clone)]
-pub struct KeyService;
+pub(crate) struct KeyService;
 
 impl KeyService {
     /// Creates a new api key.
@@ -23,12 +23,12 @@ impl KeyService {
     /// - `req`: The request to send.
     ///
     /// # Returns
-    /// A result containing the response, or an [`HttpError`].
+    /// A wrapper around the response, or an [`HttpError`].
     pub async fn create_key(
         &self,
         http: &HttpService,
         req: CreateKeyRequest,
-    ) -> Response<CreateKeyResponse> {
+    ) -> Wrapped<CreateKeyResponse> {
         let route = routes::CREATE_KEY.compile();
         let response = http.fetch(route, Some(req)).await;
 
@@ -42,12 +42,12 @@ impl KeyService {
     /// - `req`: The request to send.
     ///
     /// # Returns
-    /// A result containing the response, or an [`HttpError`].
+    /// A wrapper around the response, or an [`HttpError`].
     pub async fn verify_key(
         &self,
         http: &HttpService,
         req: VerifyKeyRequest,
-    ) -> Response<VerifyKeyResponse> {
+    ) -> Wrapped<VerifyKeyResponse> {
         let route = routes::VERIFY_KEY.compile();
         let response = http.fetch(route, Some(req)).await;
 

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -2,6 +2,6 @@ mod apis;
 mod http;
 mod keys;
 
-pub use apis::*;
-pub use http::*;
-pub use keys::*;
+pub(crate) use apis::*;
+pub(crate) use http::*;
+pub(crate) use keys::*;


### PR DESCRIPTION
## Summary

- Refactored the visibility of the `routes` and `services` module.
- Moved and renamed `types.rs` to `models/http.rs`.
- Renamed `Response<T>` to `Wrapped<T>`.
- Updated the CI to fail if `clippy` doesnt pass.

## Checklist

<!--
- [x] Correct
- [X] Correct
-->

- [x] I have run `cargo test` and all tests pass.
- [x] I have run `cargo fmt` and the code is formatted.
- [x] I have run `cargo clippy` in pedantic mode and refactored.
- [x] I have included documentation for any new structs or methods.
- [x] I have updated tests for any code I addded/changed/deleted.

## Related Issues

- Closes #14 
