### PR TITLE
Implement revoke key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `KeyService` for key related requests.
 - Add `create_key` method.
 - Add `verify_key` method.
+- Add `revoke_key` method.
 - Add `list_keys` method.
 - Add various models supporting api service.
 - Add various models supporting key service.

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,6 +2,7 @@ use crate::models::CreateKeyRequest;
 use crate::models::CreateKeyResponse;
 use crate::models::ListKeysRequest;
 use crate::models::ListKeysResponse;
+use crate::models::RevokeKeyRequest;
 use crate::models::VerifyKeyRequest;
 use crate::models::VerifyKeyResponse;
 use crate::models::Wrapped;
@@ -182,5 +183,32 @@ impl Client {
     /// ```
     pub async fn list_keys(&self, req: ListKeysRequest) -> Wrapped<ListKeysResponse> {
         self.apis.list_keys(&self.http, req).await
+    }
+
+    /// Revokes an existing api key.
+    ///
+    /// # Arguments
+    /// - `req`: The revoke key request to send.
+    ///
+    /// # Returns
+    /// A wrapper containing the empty response, or an [`HttpError`].
+    ///
+    /// # Example
+    /// ```no_run
+    /// # async fn revoke() {
+    /// # use unkey::Client;
+    /// # use unkey::models::RevokeKeyRequest;
+    /// # use unkey::models::Wrapped;
+    /// let c = Client::new("abc123");
+    /// let req = RevokeKeyRequest::new("test_123");
+    ///
+    /// match c.revoke_key(req).await {
+    ///     Wrapped::Ok(_) => println!("Success!"), // Nothing on success
+    ///     Wrapped::Err(err) => println!("{:?}", err),
+    /// }
+    /// # }
+    /// ```
+    pub async fn revoke_key(&self, req: RevokeKeyRequest) -> Wrapped<()> {
+        self.keys.revoke_key(&self.http, req).await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,35 @@ where
     }
 }
 
+/// Wraps the http result for an empty return value.
+///
+/// # Arguments
+/// - `result`: The http result from the request.
+///
+/// # Returns
+/// The wrapped response or an error.
+pub(crate) async fn wrap_empty_response(result: HttpResult) -> Wrapped<()> {
+    let data = match result {
+        Ok(r) => r.text().await,
+        Err(e) => {
+            logging::error!(format!("HTTP request failed: {}", e.to_string()));
+            Err(e)
+        }
+    };
+
+    match data {
+        Err(e) => response_error!(ErrorCode::Unknown, e),
+        Ok(text) => {
+            logging::debug!(format!("INCOMING: {text}"));
+
+            match serde_json::from_str::<Wrapped<()>>(&text) {
+                Err(_) => Wrapped::Ok(()), // Is this really the only way?
+                Ok(r) => r,
+            }
+        }
+    }
+}
+
 macro_rules! fetch {
     ($http:expr, $route:ident) => {
         $http.fetch($route, None::<u8>)

--- a/src/models/keys.rs
+++ b/src/models/keys.rs
@@ -376,3 +376,34 @@ pub struct ApiKey {
     /// The ratelimit imposed on this key, if any.
     pub ratelimit: Option<Ratelimit>,
 }
+
+/// An outgoing revoke key request.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RevokeKeyRequest {
+    /// The unique id of the key to revoke.
+    pub key_id: String,
+}
+
+impl RevokeKeyRequest {
+    /// Creates a new revoke key request.
+    ///
+    /// # Arguments
+    /// - `key_id`: The id of the key to revoke.
+    ///
+    /// # Returns
+    /// The revoke key request.
+    ///
+    /// # Example
+    /// ```
+    /// # use unkey::models::RevokeKeyRequest;
+    /// let r = RevokeKeyRequest::new("test_ABC123");
+    ///
+    /// assert_eq!(r.key_id, String::from("test_ABC123"));
+    /// ```
+    #[must_use]
+    #[rustfmt::skip]
+    pub fn new<T: Into<String>>(key_id: T) -> Self {
+        Self { key_id: key_id.into() }
+    }
+}

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -11,8 +11,7 @@ pub(crate) static CREATE_KEY: Route = Route::new(Method::POST, "/keys");
 pub(crate) static VERIFY_KEY: Route = Route::new(Method::POST, "/keys/verify");
 
 /// The delete key endpoint `DELETE /keys/{id}`
-#[allow(unused)] // Temporary until we implement this method
-pub(crate) static DELETE_KEY: Route = Route::new(Method::DELETE, "/keys/{}");
+pub(crate) static REVOKE_KEY: Route = Route::new(Method::DELETE, "/keys/{}");
 
 /// The update key endpoint `PUT /keys/{id}`
 #[allow(unused)] // Temporary until we implement this method

--- a/src/services/apis.rs
+++ b/src/services/apis.rs
@@ -1,11 +1,10 @@
 use crate::fetch;
-use crate::routes;
-use crate::wrap_response;
-
 use crate::models::ListKeysRequest;
 use crate::models::ListKeysResponse;
 use crate::models::Wrapped;
+use crate::routes;
 use crate::services::HttpService;
+use crate::wrap_response;
 
 #[allow(unused_imports)]
 use crate::models::HttpError;

--- a/src/services/keys.rs
+++ b/src/services/keys.rs
@@ -1,13 +1,14 @@
 use crate::fetch;
-use crate::routes;
-use crate::wrap_response;
-
 use crate::models::CreateKeyRequest;
 use crate::models::CreateKeyResponse;
+use crate::models::RevokeKeyRequest;
 use crate::models::VerifyKeyRequest;
 use crate::models::VerifyKeyResponse;
 use crate::models::Wrapped;
+use crate::routes;
 use crate::services::HttpService;
+use crate::wrap_empty_response;
+use crate::wrap_response;
 
 #[allow(unused_imports)]
 use crate::models::HttpError;
@@ -51,5 +52,20 @@ impl KeyService {
         let route = routes::VERIFY_KEY.compile();
 
         wrap_response(fetch!(http, route, req).await).await
+    }
+
+    /// Revokes an existing api key.
+    ///
+    /// # Arguments
+    /// - `http`: The http service to use for the request.
+    /// - `req`: The request to send.
+    ///
+    /// # Returns
+    /// A wrapper around an empty response, or an [`HttpError`].
+    pub async fn revoke_key(&self, http: &HttpService, req: RevokeKeyRequest) -> Wrapped<()> {
+        let mut route = routes::REVOKE_KEY.compile();
+        route.uri_insert(&req.key_id);
+
+        wrap_empty_response(fetch!(http, route, req).await).await
     }
 }


### PR DESCRIPTION
## Summary

This PR implements the `revoke_key` method on the client and key service.

Had to create a new `wrap_empty_response` helper function as I couldn't get serde to deserialize the empty response into anything. Maybe in the future we can find a nicer way to do it, but for now it works.

## Checklist

<!--
- [x] Correct
- [X] Correct
-->

- [x] I have run `cargo test` and all tests pass.
- [x] I have run `cargo fmt` and the code is formatted.
- [x] I have run `cargo clippy` in pedantic mode and refactored.
- [x] I have included documentation for any new structs or methods.
- [x] I have updated tests for any code I addded/changed/deleted.
- [x] I have updated the CHANGELOG to include my changes.

## Related Issues

- Closes #1 
