### PR TITLE
Pin serde due to security concerns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,12 @@ documentation = "https://docs.rs/unkey"
 keywords = ["unkey-sdk", "unkey", "unkeyed", "api"]
 categories = ["api-bindings", "asynchronous"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [lib]
 name = "unkey"
 
 [dependencies]
 lazy_static = "1.4.0"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "=1.0.171", features = ["derive"] }
 serde_json = "1"
 
 [dependencies.reqwest]


### PR DESCRIPTION
## Summary

This PR pins `serde` to v1.0.171 as they recently started shipping precompiled binaries for derive.

## Checklist

- [x] I have run `cargo test` and all tests pass.
- [x] I have run `cargo fmt` and the code is formatted.
- [x] I have run `cargo clippy` in pedantic mode and refactored.
- [x] I have included documentation for any new structs or methods.
- [x] I have updated tests for any code I addded/changed/deleted.
- [ ] I have updated the CHANGELOG to include my changes.

## Related Issues

- serde-rs/serde#2538
- rust-lang/cargo#12528
