### PR TITLE
Unpin serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "unkey"
 
 [dependencies]
 lazy_static = "1.4.0"
-serde = { version = "=1.0.171", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dependencies.reqwest]


### PR DESCRIPTION
## Summary

This PR unpins `serde` from 1.0.171 after the removal of the precompiled binary.

## Checklist

- [x] I have run `cargo test` and all tests pass.
- [x] I have run `cargo fmt` and the code is formatted.
- [x] I have run `cargo clippy` in pedantic mode and refactored.
- [x] I have included documentation for any new structs or methods.
- [x] I have updated tests for any code I addded/changed/deleted.
- [ ] I have updated the CHANGELOG to include my changes.

## Related Issues

- See serde-rs/serde#2590
