### PR TITLE
Implement update key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 - Add `create_key` method.
 - Add `verify_key` method.
 - Add `revoke_key` method.
+- Add `update_key` method.
 - Add `list_keys` method.
+- Add `get_api` method.
 - Add various models supporting api service.
 - Add various models supporting key service.
-- Add `get_api` method.

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,6 +5,7 @@ use crate::models::GetApiResponse;
 use crate::models::ListKeysRequest;
 use crate::models::ListKeysResponse;
 use crate::models::RevokeKeyRequest;
+use crate::models::UpdateKeyRequest;
 use crate::models::VerifyKeyRequest;
 use crate::models::VerifyKeyResponse;
 use crate::models::Wrapped;
@@ -239,5 +240,32 @@ impl Client {
     /// ````
     pub async fn get_api(&self, req: GetApiRequest) -> Wrapped<GetApiResponse> {
         self.apis.get_api(&self.http, req).await
+    }
+
+    /// Retrieves information for the given api id.
+    ///
+    /// # Arguments
+    /// - `req`: The get api request to send.
+    ///
+    /// # Returns
+    /// A wrapper containing the response, or an [`HttpError`].
+    ///
+    /// # Example
+    /// ```no_run
+    /// # async fn get() {
+    /// # use unkey::Client;
+    /// # use unkey::models::UpdateKeyRequest;
+    /// # use unkey::models::Wrapped;
+    /// let c = Client::new("abc123");
+    /// let req = UpdateKeyRequest::new("api_id").set_remaining(Some(100));
+    ///
+    /// match c.update_key(req).await {
+    ///     Wrapped::Ok(res) => println!("{:?}", res),
+    ///     Wrapped::Err(err) => println!("{:?}", err),
+    /// }
+    /// # }
+    /// ````
+    pub async fn update_key(&self, req: UpdateKeyRequest) -> Wrapped<()> {
+        self.keys.update_key(&self.http, req).await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
+#![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
+
 mod client;
 mod logging;
 pub mod models;
 mod routes;
 mod services;
+pub mod undefined;
 
 use serde::Deserialize;
 
@@ -10,16 +13,6 @@ pub use client::Client;
 use models::ErrorCode;
 use models::HttpResult;
 use models::Wrapped;
-
-/// Represents the potential absence of a value beyond `None`.
-#[derive(Debug, Clone)]
-pub(crate) enum Undefined<T> {
-    /// The value is present.
-    Some(T),
-
-    /// The value is not present.
-    None,
-}
 
 /// Creates a new Err variant of [`Response`].
 ///
@@ -106,6 +99,7 @@ pub(crate) async fn wrap_empty_response(result: HttpResult) -> Wrapped<()> {
     }
 }
 
+/// Fetchs the given route with the provided http service.
 macro_rules! fetch {
     ($http:expr, $route:ident) => {
         $http.fetch($route, None::<u8>)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,16 @@ use models::ErrorCode;
 use models::HttpResult;
 use models::Wrapped;
 
+/// Represents the potential absence of a value beyond `None`.
+#[derive(Debug, Clone)]
+pub(crate) enum Undefined<T> {
+    /// The value is present.
+    Some(T),
+
+    /// The value is not present.
+    None,
+}
+
 /// Creates a new Err variant of [`Response`].
 ///
 /// # Arguments

--- a/src/models/keys.rs
+++ b/src/models/keys.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 use super::Ratelimit;
 use super::RatelimitState;
-use crate::Undefined;
+use crate::undefined::UndefinedOr;
 
 /// An outgoing verify key request.
 #[derive(Debug, Clone, Serialize)]
@@ -409,35 +409,296 @@ impl RevokeKeyRequest {
     }
 }
 
-#[derive(Debug, Clone)]
+/// An outgoing update key request.
+///
+/// ## Note
+/// All optional values are initialized to the [`UndefinedOr::Undefined`] state.
+/// Upon calling the `set_x` method, you may set the value to `Some(_)` or
+/// `None`. Setting the value to `None` indicates you would like to remove any
+/// value that is currently set for that field on the key.
+///
+/// e.g. The key you are updating currently has a ratelimit and you call
+/// `set_ratelimit(None)` on the update key request. The key will no longer
+/// have a ratelimit.
+#[derive(Debug, Default, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UpdateKeyRequest {
     /// The id of the key to update.
     pub key_id: String,
 
     /// The optional new owner id for the key.
-    pub owner_id: Undefined<Option<String>>,
+    #[serde(skip_serializing_if = "UndefinedOr::is_undefined")]
+    pub owner_id: UndefinedOr<Option<String>>,
 
     /// The optional new name for the key.
-    pub name: Option<String>,
+    #[serde(skip_serializing_if = "UndefinedOr::is_undefined")]
+    pub name: UndefinedOr<Option<String>>,
 
     /// The optional new dynamic meta mapping for the key.
-    pub meta: Option<Value>,
+    #[serde(skip_serializing_if = "UndefinedOr::is_undefined")]
+    pub meta: UndefinedOr<Option<Value>>,
 
     /// The optional new unix epoch in ms when the key should expire.
-    pub expires: Option<usize>,
+    #[serde(skip_serializing_if = "UndefinedOr::is_undefined")]
+    pub expires: UndefinedOr<Option<usize>>,
 
     /// The optional new number of uses remaining to set for the key.
-    pub remaining: Option<usize>,
+    #[serde(skip_serializing_if = "UndefinedOr::is_undefined")]
+    pub remaining: UndefinedOr<Option<usize>>,
 
     /// The optional new ratelimit to set for the key.
-    pub ratelimit: Option<Ratelimit>,
+    #[serde(skip_serializing_if = "UndefinedOr::is_undefined")]
+    pub ratelimit: UndefinedOr<Option<Ratelimit>>,
 }
 
-impl Serialize for UpdateKeyRequest {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        todo!()
+impl UpdateKeyRequest {
+    /// Creates a new update key request.
+    ///
+    /// # Arguments
+    /// - `key_id`: The id of the key to update.
+    ///
+    /// # Returns
+    /// The new update key request.
+    ///
+    /// # Example
+    /// ```
+    /// # use unkey::models::UpdateKeyRequest;
+    /// # use unkey::undefined::UndefinedOr;
+    /// let r = UpdateKeyRequest::new("test_123");
+    ///
+    /// assert_eq!(r.key_id, String::from("test_123"));
+    /// assert_eq!(r.owner_id, UndefinedOr::Undefined);
+    /// assert_eq!(r.name, UndefinedOr::Undefined);
+    /// assert_eq!(r.meta, UndefinedOr::Undefined);
+    /// assert_eq!(r.expires, UndefinedOr::Undefined);
+    /// assert_eq!(r.remaining, UndefinedOr::Undefined);
+    /// assert_eq!(r.ratelimit, UndefinedOr::Undefined);
+    /// ```
+    #[must_use]
+    pub fn new<T: Into<String>>(key_id: T) -> Self {
+        Self {
+            key_id: key_id.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Sets or unsets the owner id for the key.
+    ///
+    /// # Arguments
+    /// - `owner_id`: The owner id to set or unset.
+    ///
+    /// # Returns
+    /// Self for chained calls.
+    ///
+    /// # Example
+    /// ```
+    /// # use unkey::models::UpdateKeyRequest;
+    /// # use unkey::undefined::UndefinedOr;
+    /// let r = UpdateKeyRequest::new("test");
+    ///
+    /// assert_eq!(r.owner_id, UndefinedOr::Undefined);
+    /// assert_eq!(*r.owner_id, None);
+    ///
+    /// let r = r.set_owner_id(Some("jonxslays"));
+    ///
+    /// assert_eq!(r.owner_id, UndefinedOr::Value(Some(String::from("jonxslays"))));
+    /// assert_eq!(*r.owner_id, Some(String::from("jonxslays")));
+    ///
+    /// let r = r.set_owner_id(None);
+    ///
+    /// assert_eq!(r.owner_id, UndefinedOr::Null);
+    /// assert_eq!(*r.owner_id, None);
+    /// ```
+    #[must_use]
+    pub fn set_owner_id(mut self, owner_id: Option<&str>) -> Self {
+        self.owner_id = match owner_id {
+            Some(id) => Some(id.into()).into(),
+            None => None.into(),
+        };
+
+        self
+    }
+
+    /// Sets or unsets the name for the key.
+    ///
+    /// # Arguments
+    /// - `name`: The name to set or unset.
+    ///
+    /// # Returns
+    /// Self for chained calls.
+    ///
+    /// # Example
+    /// ```
+    /// # use unkey::models::UpdateKeyRequest;
+    /// # use unkey::undefined::UndefinedOr;
+    /// let r = UpdateKeyRequest::new("test");
+    ///
+    /// assert_eq!(r.name, UndefinedOr::Undefined);
+    /// assert_eq!(*r.name, None);
+    ///
+    /// let r = r.set_name(Some("test_key"));
+    ///
+    /// assert_eq!(r.name, UndefinedOr::Value(Some(String::from("test_key"))));
+    /// assert_eq!(*r.name, Some(String::from("test_key")));
+    ///
+    /// let r = r.set_name(None);
+    ///
+    /// assert_eq!(r.name, UndefinedOr::Null);
+    /// assert_eq!(*r.name, None);
+    /// ```
+    #[must_use]
+    pub fn set_name(mut self, name: Option<&str>) -> Self {
+        self.name = match name {
+            Some(n) => Some(n.into()).into(),
+            None => None.into(),
+        };
+
+        self
+    }
+
+    /// Sets or unsets the dynamic meta mapping for the key.
+    ///
+    /// # Arguments
+    /// - `meta`: The meta to set or unset.
+    ///
+    /// # Returns
+    /// Self for chained calls.
+    ///
+    /// # Example
+    /// ```
+    /// # use unkey::models::UpdateKeyRequest;
+    /// # use unkey::undefined::UndefinedOr;
+    /// # use serde_json::json;
+    /// let r = UpdateKeyRequest::new("test");
+    ///
+    /// assert_eq!(r.meta, UndefinedOr::Undefined);
+    /// assert_eq!(*r.meta, None);
+    ///
+    /// let r = r.set_meta(Some(json!({"test": 69})));
+    ///
+    /// assert_eq!(r.meta, UndefinedOr::Value(Some(json!({"test": 69}))));
+    /// assert_eq!(*r.meta, Some(json!({"test": 69})));
+    ///
+    /// let r = r.set_meta(None);
+    ///
+    /// assert_eq!(r.meta, UndefinedOr::Null);
+    /// assert_eq!(*r.meta, None);
+    /// ```
+    #[must_use]
+    pub fn set_meta(mut self, meta: Option<Value>) -> Self {
+        self.meta = match meta {
+            Some(m) => Some(m).into(),
+            None => None.into(),
+        };
+
+        self
+    }
+
+    /// Sets or unsets the unix epoch in ms indicating when this key expires.
+    ///
+    /// # Arguments
+    /// - `expires`: The expiration epoch to set or unset.
+    ///
+    /// # Returns
+    /// Self for chained calls.
+    ///
+    /// # Example
+    /// ```
+    /// # use unkey::models::UpdateKeyRequest;
+    /// # use unkey::undefined::UndefinedOr;
+    /// let r = UpdateKeyRequest::new("test");
+    ///
+    /// assert_eq!(r.expires, UndefinedOr::Undefined);
+    /// assert_eq!(*r.expires, None);
+    ///
+    /// let r = r.set_expires(Some(42));
+    ///
+    /// assert_eq!(r.expires, UndefinedOr::Value(Some(42)));
+    /// assert_eq!(*r.expires, Some(42));
+    ///
+    /// let r = r.set_expires(None);
+    ///
+    /// assert_eq!(r.expires, UndefinedOr::Null);
+    /// assert_eq!(*r.expires, None);
+    /// ```
+    #[must_use]
+    pub fn set_expires(mut self, expires: Option<usize>) -> Self {
+        self.expires = expires.into();
+        self
+    }
+
+    /// Sets or unsets the remaining uses for the key.
+    ///
+    /// # Arguments
+    /// - `remaining`: The number of remaining uses to set or unset.
+    ///
+    /// # Returns
+    /// Self for chained calls.
+    ///
+    /// # Example
+    /// ```
+    /// # use unkey::models::UpdateKeyRequest;
+    /// # use unkey::undefined::UndefinedOr;
+    /// let r = UpdateKeyRequest::new("test");
+    ///
+    /// assert_eq!(r.remaining, UndefinedOr::Undefined);
+    /// assert_eq!(*r.remaining, None);
+    ///
+    /// let r = r.set_remaining(Some(420));
+    ///
+    /// assert_eq!(r.remaining, UndefinedOr::Value(Some(420)));
+    /// assert_eq!(*r.remaining, Some(420));
+    ///
+    /// let r = r.set_remaining(None);
+    ///
+    /// assert_eq!(r.remaining, UndefinedOr::Null);
+    /// assert_eq!(*r.remaining, None);
+    /// ```
+    #[must_use]
+    pub fn set_remaining(mut self, remaining: Option<usize>) -> Self {
+        self.remaining = remaining.into();
+        self
+    }
+
+    /// Sets or unsets the ratelimit for the key.
+    ///
+    /// # Arguments
+    /// - `ratelimit`: The ratelimit to set or unset.
+    ///
+    /// # Returns
+    /// Self for chained calls.
+    ///
+    /// # Example
+    /// ```
+    /// # use unkey::models::UpdateKeyRequest;
+    /// # use unkey::models::Ratelimit;
+    /// # use unkey::models::RatelimitType;
+    /// # use unkey::undefined::UndefinedOr;
+    /// let r = UpdateKeyRequest::new("test");
+    ///
+    /// assert_eq!(r.ratelimit, UndefinedOr::Undefined);
+    /// assert_eq!(*r.ratelimit, None);
+    ///
+    /// let ratelimit = Ratelimit::new(
+    ///     RatelimitType::Fast,
+    ///     10,
+    ///     10000,
+    ///     100
+    /// );
+    ///
+    /// let r = r.set_ratelimit(Some(ratelimit.clone()));
+    ///
+    /// assert_eq!(r.ratelimit, UndefinedOr::Value(Some(ratelimit.clone())));
+    /// assert_eq!(*r.ratelimit, Some(ratelimit));
+    ///
+    /// let r = r.set_ratelimit(None);
+    ///
+    /// assert_eq!(r.ratelimit, UndefinedOr::Null);
+    /// assert_eq!(*r.ratelimit, None);
+    /// ```
+    #[must_use]
+    pub fn set_ratelimit(mut self, ratelimit: Option<Ratelimit>) -> Self {
+        self.ratelimit = ratelimit.into();
+        self
     }
 }

--- a/src/models/keys.rs
+++ b/src/models/keys.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 
 use super::Ratelimit;
 use super::RatelimitState;
+use crate::Undefined;
 
 /// An outgoing verify key request.
 #[derive(Debug, Clone, Serialize)]
@@ -405,5 +406,38 @@ impl RevokeKeyRequest {
     #[rustfmt::skip]
     pub fn new<T: Into<String>>(key_id: T) -> Self {
         Self { key_id: key_id.into() }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateKeyRequest {
+    /// The id of the key to update.
+    pub key_id: String,
+
+    /// The optional new owner id for the key.
+    pub owner_id: Undefined<Option<String>>,
+
+    /// The optional new name for the key.
+    pub name: Option<String>,
+
+    /// The optional new dynamic meta mapping for the key.
+    pub meta: Option<Value>,
+
+    /// The optional new unix epoch in ms when the key should expire.
+    pub expires: Option<usize>,
+
+    /// The optional new number of uses remaining to set for the key.
+    pub remaining: Option<usize>,
+
+    /// The optional new ratelimit to set for the key.
+    pub ratelimit: Option<Ratelimit>,
+}
+
+impl Serialize for UpdateKeyRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        todo!()
     }
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -14,7 +14,6 @@ pub(crate) static VERIFY_KEY: Route = Route::new(Method::POST, "/keys/verify");
 pub(crate) static REVOKE_KEY: Route = Route::new(Method::DELETE, "/keys/{}");
 
 /// The update key endpoint `PUT /keys/{id}`
-#[allow(unused)] // Temporary until we implement this method
 pub(crate) static UPDATE_KEY: Route = Route::new(Method::PUT, "/keys/{}");
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/services/keys.rs
+++ b/src/services/keys.rs
@@ -2,6 +2,7 @@ use crate::fetch;
 use crate::models::CreateKeyRequest;
 use crate::models::CreateKeyResponse;
 use crate::models::RevokeKeyRequest;
+use crate::models::UpdateKeyRequest;
 use crate::models::VerifyKeyRequest;
 use crate::models::VerifyKeyResponse;
 use crate::models::Wrapped;
@@ -64,6 +65,21 @@ impl KeyService {
     /// A wrapper around an empty response, or an [`HttpError`].
     pub async fn revoke_key(&self, http: &HttpService, req: RevokeKeyRequest) -> Wrapped<()> {
         let mut route = routes::REVOKE_KEY.compile();
+        route.uri_insert(&req.key_id);
+
+        wrap_empty_response(fetch!(http, route, req).await).await
+    }
+
+    /// Updates an existing api key.
+    ///
+    /// # Arguments
+    /// - `http`: The http service to use for the request.
+    /// - `req`: The request to send.
+    ///
+    /// # Returns
+    /// A wrapper around an empty response, or an [`HttpError`].
+    pub async fn update_key(&self, http: &HttpService, req: UpdateKeyRequest) -> Wrapped<()> {
+        let mut route = routes::UPDATE_KEY.compile();
         route.uri_insert(&req.key_id);
 
         wrap_empty_response(fetch!(http, route, req).await).await

--- a/src/undefined.rs
+++ b/src/undefined.rs
@@ -1,0 +1,79 @@
+use serde::ser::Error;
+use serde::Serialize;
+use std::ops::Deref;
+
+/// Represents the potential absence of a value beyond `None`.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum UndefinedOr<T> {
+    /// The value is present (T).
+    Value(T),
+
+    /// The value is present (null).
+    Null,
+
+    /// The value is not present (undefined).
+    Undefined,
+}
+
+impl<T> UndefinedOr<T> {
+    pub fn is_some(&self) -> bool {
+        match self {
+            Self::Value(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_undefined(&self) -> bool {
+        match self {
+            Self::Undefined => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_null(&self) -> bool {
+        match self {
+            Self::Null => true,
+            _ => false,
+        }
+    }
+}
+
+impl<T> Default for UndefinedOr<T> {
+    fn default() -> Self {
+        Self::Undefined
+    }
+}
+
+impl<T: Serialize> Serialize for UndefinedOr<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Null => serializer.serialize_none(),
+            Self::Value(v) => v.serialize(serializer),
+            Self::Undefined => Err(Error::custom("Undefined should never be serialized.")),
+        }
+    }
+}
+
+impl<T> From<Option<T>> for UndefinedOr<T> {
+    fn from(value: Option<T>) -> Self {
+        match value {
+            Some(v) => Self::Value(v),
+            None => Self::Null,
+        }
+    }
+}
+
+impl<T> Deref for UndefinedOr<Option<T>> {
+    type Target = Option<T>;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Value(v) => &v,
+            Self::Null => &None::<T>,
+            Self::Undefined => &None::<T>,
+        }
+    }
+}

--- a/src/undefined.rs
+++ b/src/undefined.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::module_name_repetitions)]
+
 use serde::ser::Error;
 use serde::Serialize;
 use std::ops::Deref;
@@ -17,24 +19,15 @@ pub enum UndefinedOr<T> {
 
 impl<T> UndefinedOr<T> {
     pub fn is_some(&self) -> bool {
-        match self {
-            Self::Value(_) => true,
-            _ => false,
-        }
+        matches!(self, Self::Value(_))
     }
 
     pub fn is_undefined(&self) -> bool {
-        match self {
-            Self::Undefined => true,
-            _ => false,
-        }
+        matches!(self, Self::Undefined)
     }
 
     pub fn is_null(&self) -> bool {
-        match self {
-            Self::Null => true,
-            _ => false,
-        }
+        matches!(self, Self::Null)
     }
 }
 
@@ -71,9 +64,8 @@ impl<T> Deref for UndefinedOr<Option<T>> {
 
     fn deref(&self) -> &Self::Target {
         match self {
-            Self::Value(v) => &v,
-            Self::Null => &None::<T>,
-            Self::Undefined => &None::<T>,
+            Self::Value(v) => v,
+            _ => &None::<T>,
         }
     }
 }

--- a/src/undefined.rs
+++ b/src/undefined.rs
@@ -57,10 +57,10 @@ impl<T: Serialize> Serialize for UndefinedOr<T> {
     }
 }
 
-impl<T> From<Option<T>> for UndefinedOr<T> {
+impl<T> From<Option<T>> for UndefinedOr<Option<T>> {
     fn from(value: Option<T>) -> Self {
         match value {
-            Some(v) => Self::Value(v),
+            Some(v) => Self::Value(Some(v)),
             None => Self::Null,
         }
     }


### PR DESCRIPTION
## Summary

This PR implements the update key endpoint.

- Service method
- Client method
- Models

Adds a new `UndefinedOr<T>` enum that can distinguish between `null` and `undefined` json values.

## Checklist

- [x] I have run `cargo test` and all tests pass.
- [x] I have run `cargo fmt` and the code is formatted.
- [x] I have run `cargo clippy` in pedantic mode and refactored.
- [x] I have included documentation for any new structs or methods.
- [x] I have updated tests for any code I addded/changed/deleted.
- [x] I have updated the CHANGELOG to include my changes.

## Related Issues

- Closes #2 
