### PR TITLE
Improve `UndefinedOr` and tests

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -19,7 +19,7 @@ use crate::models::HttpError;
 /// The client used to make requests to the unkey api.
 #[derive(Debug, Clone)]
 pub struct Client {
-    /// The internal http sending and receiving requests.
+    /// The internal http service sending and receiving requests.
     http: HttpService,
 
     /// The key service handling key related requests.
@@ -268,4 +268,22 @@ impl Client {
     pub async fn update_key(&self, req: UpdateKeyRequest) -> Wrapped<()> {
         self.keys.update_key(&self.http, req).await
     }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::services::ApiService;
+    use crate::services::KeyService;
+    use crate::Client;
+
+    #[test]
+    fn new() {
+        let c = Client::new("");
+
+        assert_eq!(c.apis, ApiService);
+        assert_eq!(c.keys, KeyService);
+    }
+
+    // TODO: Write a custom API to run for integration tests with the client.
+    // It will be the clients base URL for testing requests.
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,3 +110,52 @@ macro_rules! fetch {
 }
 
 pub(crate) use fetch;
+
+#[cfg(test)]
+mod test {
+    use crate::models::ErrorCode;
+    use crate::models::HttpError;
+    use crate::models::Wrapped;
+
+    struct FakeHttp;
+
+    impl FakeHttp {
+        pub fn fetch(&self, route: u8, payload: Option<u8>) -> u8 {
+            let mut res = route;
+            if let Some(p) = payload {
+                res += p;
+            }
+
+            res
+        }
+    }
+
+    #[test]
+    fn reponse_error() {
+        let res: Wrapped<()> = response_error!(ErrorCode::NotFound, "not found!");
+
+        assert_eq!(
+            res,
+            Wrapped::Err(HttpError::new(
+                ErrorCode::NotFound,
+                String::from("not found!")
+            ))
+        );
+    }
+
+    #[test]
+    fn fetch_no_payload() {
+        let route = 69;
+        let res = fetch!(FakeHttp, route);
+
+        assert_eq!(res, 69);
+    }
+
+    #[test]
+    fn fetch_with_payload() {
+        let route = 69;
+        let res = fetch!(FakeHttp, route, 1);
+
+        assert_eq!(res, 70);
+    }
+}

--- a/src/models/apis.rs
+++ b/src/models/apis.rs
@@ -122,6 +122,7 @@ pub struct ListKeysResponse {
     pub total: usize,
 }
 
+/// An outgoing get api request.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetApiRequest {
@@ -129,7 +130,6 @@ pub struct GetApiRequest {
     pub api_id: String,
 }
 
-/// An outgoing get api request.
 impl GetApiRequest {
     /// Creates a new get api request.
     ///

--- a/src/models/http.rs
+++ b/src/models/http.rs
@@ -35,7 +35,7 @@ pub enum ErrorCode {
 
 /// An http error representation.
 #[allow(clippy::module_name_repetitions)]
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Eq, PartialEq)]
 pub struct HttpError {
     /// The error code for the error.
     pub code: ErrorCode,
@@ -73,7 +73,7 @@ impl HttpError {
 }
 
 /// A wrapper around the response type or an error.
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
 pub enum Wrapped<T> {
     /// The error value.
     #[serde(rename = "error")]

--- a/src/models/keys.rs
+++ b/src/models/keys.rs
@@ -428,27 +428,27 @@ pub struct UpdateKeyRequest {
 
     /// The optional new owner id for the key.
     #[serde(skip_serializing_if = "UndefinedOr::is_undefined")]
-    pub owner_id: UndefinedOr<Option<String>>,
+    pub owner_id: UndefinedOr<String>,
 
     /// The optional new name for the key.
     #[serde(skip_serializing_if = "UndefinedOr::is_undefined")]
-    pub name: UndefinedOr<Option<String>>,
+    pub name: UndefinedOr<String>,
 
     /// The optional new dynamic meta mapping for the key.
     #[serde(skip_serializing_if = "UndefinedOr::is_undefined")]
-    pub meta: UndefinedOr<Option<Value>>,
+    pub meta: UndefinedOr<Value>,
 
     /// The optional new unix epoch in ms when the key should expire.
     #[serde(skip_serializing_if = "UndefinedOr::is_undefined")]
-    pub expires: UndefinedOr<Option<usize>>,
+    pub expires: UndefinedOr<usize>,
 
     /// The optional new number of uses remaining to set for the key.
     #[serde(skip_serializing_if = "UndefinedOr::is_undefined")]
-    pub remaining: UndefinedOr<Option<usize>>,
+    pub remaining: UndefinedOr<usize>,
 
     /// The optional new ratelimit to set for the key.
     #[serde(skip_serializing_if = "UndefinedOr::is_undefined")]
-    pub ratelimit: UndefinedOr<Option<Ratelimit>>,
+    pub ratelimit: UndefinedOr<Ratelimit>,
 }
 
 impl UpdateKeyRequest {
@@ -497,17 +497,17 @@ impl UpdateKeyRequest {
     /// let r = UpdateKeyRequest::new("test");
     ///
     /// assert_eq!(r.owner_id, UndefinedOr::Undefined);
-    /// assert_eq!(*r.owner_id, None);
+    /// assert_eq!(r.owner_id.inner(), None);
     ///
     /// let r = r.set_owner_id(Some("jonxslays"));
     ///
-    /// assert_eq!(r.owner_id, UndefinedOr::Value(Some(String::from("jonxslays"))));
-    /// assert_eq!(*r.owner_id, Some(String::from("jonxslays")));
+    /// assert_eq!(r.owner_id, UndefinedOr::Value(String::from("jonxslays")));
+    /// assert_eq!(r.owner_id.inner(), Some(&String::from("jonxslays")));
     ///
     /// let r = r.set_owner_id(None);
     ///
     /// assert_eq!(r.owner_id, UndefinedOr::Null);
-    /// assert_eq!(*r.owner_id, None);
+    /// assert_eq!(r.owner_id.inner(), None);
     /// ```
     #[must_use]
     pub fn set_owner_id(mut self, owner_id: Option<&str>) -> Self {
@@ -534,17 +534,17 @@ impl UpdateKeyRequest {
     /// let r = UpdateKeyRequest::new("test");
     ///
     /// assert_eq!(r.name, UndefinedOr::Undefined);
-    /// assert_eq!(*r.name, None);
+    /// assert_eq!(r.name.inner(), None);
     ///
     /// let r = r.set_name(Some("test_key"));
     ///
-    /// assert_eq!(r.name, UndefinedOr::Value(Some(String::from("test_key"))));
-    /// assert_eq!(*r.name, Some(String::from("test_key")));
+    /// assert_eq!(r.name, UndefinedOr::Value(String::from("test_key")));
+    /// assert_eq!(r.name.inner(), Some(&String::from("test_key")));
     ///
     /// let r = r.set_name(None);
     ///
     /// assert_eq!(r.name, UndefinedOr::Null);
-    /// assert_eq!(*r.name, None);
+    /// assert_eq!(r.name.inner(), None);
     /// ```
     #[must_use]
     pub fn set_name(mut self, name: Option<&str>) -> Self {
@@ -572,17 +572,17 @@ impl UpdateKeyRequest {
     /// let r = UpdateKeyRequest::new("test");
     ///
     /// assert_eq!(r.meta, UndefinedOr::Undefined);
-    /// assert_eq!(*r.meta, None);
+    /// assert_eq!(r.meta.inner(), None);
     ///
     /// let r = r.set_meta(Some(json!({"test": 69})));
     ///
-    /// assert_eq!(r.meta, UndefinedOr::Value(Some(json!({"test": 69}))));
-    /// assert_eq!(*r.meta, Some(json!({"test": 69})));
+    /// assert_eq!(r.meta, UndefinedOr::Value(json!({"test": 69})));
+    /// assert_eq!(r.meta.inner(), Some(&json!({"test": 69})));
     ///
     /// let r = r.set_meta(None);
     ///
     /// assert_eq!(r.meta, UndefinedOr::Null);
-    /// assert_eq!(*r.meta, None);
+    /// assert_eq!(r.meta.inner(), None);
     /// ```
     #[must_use]
     pub fn set_meta(mut self, meta: Option<Value>) -> Self {
@@ -609,17 +609,17 @@ impl UpdateKeyRequest {
     /// let r = UpdateKeyRequest::new("test");
     ///
     /// assert_eq!(r.expires, UndefinedOr::Undefined);
-    /// assert_eq!(*r.expires, None);
+    /// assert_eq!(r.expires.inner(), None);
     ///
     /// let r = r.set_expires(Some(42));
     ///
-    /// assert_eq!(r.expires, UndefinedOr::Value(Some(42)));
-    /// assert_eq!(*r.expires, Some(42));
+    /// assert_eq!(r.expires, UndefinedOr::Value(42));
+    /// assert_eq!(r.expires.inner(), Some(&42));
     ///
     /// let r = r.set_expires(None);
     ///
     /// assert_eq!(r.expires, UndefinedOr::Null);
-    /// assert_eq!(*r.expires, None);
+    /// assert_eq!(r.expires.inner(), None);
     /// ```
     #[must_use]
     pub fn set_expires(mut self, expires: Option<usize>) -> Self {
@@ -642,17 +642,17 @@ impl UpdateKeyRequest {
     /// let r = UpdateKeyRequest::new("test");
     ///
     /// assert_eq!(r.remaining, UndefinedOr::Undefined);
-    /// assert_eq!(*r.remaining, None);
+    /// assert_eq!(r.remaining.inner(), None);
     ///
     /// let r = r.set_remaining(Some(420));
     ///
-    /// assert_eq!(r.remaining, UndefinedOr::Value(Some(420)));
-    /// assert_eq!(*r.remaining, Some(420));
+    /// assert_eq!(r.remaining, UndefinedOr::Value(420));
+    /// assert_eq!(r.remaining.inner(), Some(&420));
     ///
     /// let r = r.set_remaining(None);
     ///
     /// assert_eq!(r.remaining, UndefinedOr::Null);
-    /// assert_eq!(*r.remaining, None);
+    /// assert_eq!(r.remaining.inner(), None);
     /// ```
     #[must_use]
     pub fn set_remaining(mut self, remaining: Option<usize>) -> Self {
@@ -677,7 +677,7 @@ impl UpdateKeyRequest {
     /// let r = UpdateKeyRequest::new("test");
     ///
     /// assert_eq!(r.ratelimit, UndefinedOr::Undefined);
-    /// assert_eq!(*r.ratelimit, None);
+    /// assert_eq!(r.ratelimit.inner(), None);
     ///
     /// let ratelimit = Ratelimit::new(
     ///     RatelimitType::Fast,
@@ -688,13 +688,13 @@ impl UpdateKeyRequest {
     ///
     /// let r = r.set_ratelimit(Some(ratelimit.clone()));
     ///
-    /// assert_eq!(r.ratelimit, UndefinedOr::Value(Some(ratelimit.clone())));
-    /// assert_eq!(*r.ratelimit, Some(ratelimit));
+    /// assert_eq!(r.ratelimit, UndefinedOr::Value(ratelimit.clone()));
+    /// assert_eq!(r.ratelimit.inner(), Some(&ratelimit));
     ///
     /// let r = r.set_ratelimit(None);
     ///
     /// assert_eq!(r.ratelimit, UndefinedOr::Null);
-    /// assert_eq!(*r.ratelimit, None);
+    /// assert_eq!(r.ratelimit.inner(), None);
     /// ```
     #[must_use]
     pub fn set_ratelimit(mut self, ratelimit: Option<Ratelimit>) -> Self {

--- a/src/models/ratelimit.rs
+++ b/src/models/ratelimit.rs
@@ -11,7 +11,7 @@ pub struct RatelimitState {
     /// The remaining requests in this burst window.
     pub remaining: usize,
 
-    /// The unix timestamp in ms until the next window.
+    /// The unix timestamp in ms when the next window starts.
     pub reset: usize,
 }
 

--- a/src/services/apis.rs
+++ b/src/services/apis.rs
@@ -12,7 +12,7 @@ use crate::wrap_response;
 use crate::models::HttpError;
 
 /// The service that handles api related requests.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) struct ApiService;
 
 impl ApiService {

--- a/src/services/keys.rs
+++ b/src/services/keys.rs
@@ -15,7 +15,7 @@ use crate::wrap_response;
 use crate::models::HttpError;
 
 /// The service that handles key related requests.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) struct KeyService;
 
 impl KeyService {


### PR DESCRIPTION
## Summary

This PR adds more test coverage. Not all the way there but solid enough for the first release.

It also improves the usage of `UndefinedOr`:
- No longer store the value in an Option when present.
- Remove `Deref` implementation in favor of a new method `pub fn inner(&self) -> Option<&T>`.

## Checklist

- [x] I have run `cargo test` and all tests pass.
- [x] I have run `cargo fmt` and the code is formatted.
- [x] I have run `cargo clippy` in pedantic mode and refactored.
- [x] I have included documentation for any new structs or methods.
- [x] I have updated tests for any code I addded/changed/deleted.
- [ ] I have updated the CHANGELOG to include my changes.

## Related Issues

- Closes #23 
