### PR TITLE
Add documentation for remaining public api

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Full documentation can be found at [https://docs.rs/unkey](https://docs.rs/unkey
 
 ## Setup
 
-Add the following to your `Cargo.toml` [dependencies] array:
+Add the following to your `Cargo.toml` dependencies array:
 
 ```toml
 unkey = "0.1"
@@ -28,8 +28,7 @@ unkey = "0.1"
 use unkey::models::{VerifyKeyRequest, Wrapped};
 use unkey::Client;
 
-#[tokio::main]
-async fn main() {
+async fn verify_key() {
     let c = Client::new("unkey_ABC");
     let req = VerifyKeyRequest::new("test_DEF");
 
@@ -46,8 +45,7 @@ async fn main() {
 use unkey::models::{CreateKeyRequest, Wrapped};
 use unkey::Client;
 
-#[tokio::main]
-async fn main() {
+async fn create_key()-> Result<(), ()> {
     let c = Client::new("unkey_ABC");
     let req = CreateKeyRequest::new("api_123")
         .set_prefix("test")
@@ -59,6 +57,8 @@ async fn main() {
         Wrapped::Ok(res) => println!("{res:?}"),
         Wrapped::Err(err) => eprintln!("{err:?}"),
     }
+
+    Ok(())
 }
 ```
 
@@ -68,8 +68,7 @@ async fn main() {
 use unkey::models::{UpdateKeyRequest, Wrapped};
 use unkey::Client;
 
-#[tokio::main]
-async fn main() {
+async fn update_key() {
     let c = Client::new("unkey_ABC");
     let req = UpdateKeyRequest::new("key_XYZ")
         .set_name(Some("new_name")) // Update the keys name
@@ -88,8 +87,7 @@ async fn main() {
 use unkey::models::{RevokeKeyRequest, Wrapped};
 use unkey::Client;
 
-#[tokio::main]
-async fn main() {
+async fn revoke_key() {
     let c = Client::new("unkey_ABC");
     let req = RevokeKeyRequest::new("key_XYZ");
 
@@ -106,8 +104,7 @@ async fn main() {
 use unkey::models::{ListKeysRequest, Wrapped};
 use unkey::Client;
 
-#[tokio::main]
-async fn main() {
+async fn list_keys() {
     let c = Client::new("unkey_ABC");
     let req = ListKeysRequest::new("api_123");
 
@@ -124,8 +121,7 @@ async fn main() {
 use unkey::models::{GetApiRequest, Wrapped};
 use unkey::Client;
 
-#[tokio::main]
-async fn main() {
+async fn get_api() {
     let c = Client::new("unkey_ABC");
     let req = GetApiRequest::new("api_123");
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Full documentation can be found at [https://docs.rs/unkey](https://docs.rs/unkey
 
 ## Setup
 
-Add the following to your `Cargo.toml` [dependencies]
+Add the following to your `Cargo.toml` [dependencies] array:
 
 ```toml
 unkey = "0.1"
@@ -24,7 +24,7 @@ unkey = "0.1"
 
 ### Verifying a key
 
-```rs
+```rust
 use unkey::models::{VerifyKeyRequest, Wrapped};
 use unkey::Client;
 
@@ -42,7 +42,7 @@ async fn main() {
 
 ### Creating a key
 
-```rs
+```rust
 use unkey::models::{CreateKeyRequest, Wrapped};
 use unkey::Client;
 
@@ -64,7 +64,7 @@ async fn main() {
 
 ### Updating a key
 
-```rs
+```rust
 use unkey::models::{UpdateKeyRequest, Wrapped};
 use unkey::Client;
 
@@ -84,7 +84,7 @@ async fn main() {
 
 ### Revoking a key
 
-```rs
+```rust
 use unkey::models::{RevokeKeyRequest, Wrapped};
 use unkey::Client;
 
@@ -102,7 +102,7 @@ async fn main() {
 
 ### Listing api keys
 
-```rs
+```rust
 use unkey::models::{ListKeysRequest, Wrapped};
 use unkey::Client;
 
@@ -120,7 +120,7 @@ async fn main() {
 
 ### Getting api information
 
-```rs
+```rust
 use unkey::models::{GetApiRequest, Wrapped};
 use unkey::Client;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ mod logging;
 pub mod models;
 mod routes;
 mod services;
-pub mod undefined;
 
 use serde::Deserialize;
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,5 +1,5 @@
 lazy_static::lazy_static! {
-    /// An evenironment variable containing the log level env var.
+    /// An environment variable containing the log level env var.
     pub(crate) static ref UNKEY_LOG: Log = match option_env!("UNKEY_LOG") {
         None => Log::None,
         Some(level) => match level {
@@ -14,6 +14,7 @@ lazy_static::lazy_static! {
     };
 }
 
+/// The different logging levels supported by the crate.
 #[derive(Eq, PartialEq, PartialOrd)]
 pub(crate) enum Log {
     None,
@@ -48,6 +49,7 @@ impl std::fmt::Display for Log {
     }
 }
 
+/// Logs the given message at the given level.
 macro_rules! log {
     ($level:expr, $message:expr) => {
         if *$crate::logging::UNKEY_LOG >= $level {
@@ -62,18 +64,21 @@ macro_rules! log {
     };
 }
 
+/// Logs the given message at the debug level.
 macro_rules! debug {
     ($message:expr) => {
         $crate::logging::log!($crate::logging::Log::Debug, $message)
     };
 }
 
+/// Logs the given message at the infomation level.
 macro_rules! info {
     ($message:expr) => {
         $crate::logging::log!($crate::logging::Log::Info, $message)
     };
 }
 
+/// Logs the given message at the error level.
 macro_rules! error {
     ($message:expr) => {
         $crate::logging::log!($crate::logging::Log::Error, $message)

--- a/src/models/keys.rs
+++ b/src/models/keys.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 use super::Ratelimit;
 use super::RatelimitState;
-use crate::undefined::UndefinedOr;
+use super::UndefinedOr;
 
 /// An outgoing verify key request.
 #[derive(Debug, Clone, Serialize)]
@@ -463,7 +463,7 @@ impl UpdateKeyRequest {
     /// # Example
     /// ```
     /// # use unkey::models::UpdateKeyRequest;
-    /// # use unkey::undefined::UndefinedOr;
+    /// # use unkey::models::UndefinedOr;
     /// let r = UpdateKeyRequest::new("test_123");
     ///
     /// assert_eq!(r.key_id, String::from("test_123"));
@@ -493,7 +493,7 @@ impl UpdateKeyRequest {
     /// # Example
     /// ```
     /// # use unkey::models::UpdateKeyRequest;
-    /// # use unkey::undefined::UndefinedOr;
+    /// # use unkey::models::UndefinedOr;
     /// let r = UpdateKeyRequest::new("test");
     ///
     /// assert_eq!(r.owner_id, UndefinedOr::Undefined);
@@ -530,7 +530,7 @@ impl UpdateKeyRequest {
     /// # Example
     /// ```
     /// # use unkey::models::UpdateKeyRequest;
-    /// # use unkey::undefined::UndefinedOr;
+    /// # use unkey::models::UndefinedOr;
     /// let r = UpdateKeyRequest::new("test");
     ///
     /// assert_eq!(r.name, UndefinedOr::Undefined);
@@ -567,7 +567,7 @@ impl UpdateKeyRequest {
     /// # Example
     /// ```
     /// # use unkey::models::UpdateKeyRequest;
-    /// # use unkey::undefined::UndefinedOr;
+    /// # use unkey::models::UndefinedOr;
     /// # use serde_json::json;
     /// let r = UpdateKeyRequest::new("test");
     ///
@@ -605,7 +605,7 @@ impl UpdateKeyRequest {
     /// # Example
     /// ```
     /// # use unkey::models::UpdateKeyRequest;
-    /// # use unkey::undefined::UndefinedOr;
+    /// # use unkey::models::UndefinedOr;
     /// let r = UpdateKeyRequest::new("test");
     ///
     /// assert_eq!(r.expires, UndefinedOr::Undefined);
@@ -638,7 +638,7 @@ impl UpdateKeyRequest {
     /// # Example
     /// ```
     /// # use unkey::models::UpdateKeyRequest;
-    /// # use unkey::undefined::UndefinedOr;
+    /// # use unkey::models::UndefinedOr;
     /// let r = UpdateKeyRequest::new("test");
     ///
     /// assert_eq!(r.remaining, UndefinedOr::Undefined);
@@ -673,7 +673,7 @@ impl UpdateKeyRequest {
     /// # use unkey::models::UpdateKeyRequest;
     /// # use unkey::models::Ratelimit;
     /// # use unkey::models::RatelimitType;
-    /// # use unkey::undefined::UndefinedOr;
+    /// # use unkey::models::UndefinedOr;
     /// let r = UpdateKeyRequest::new("test");
     ///
     /// assert_eq!(r.ratelimit, UndefinedOr::Undefined);

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -2,8 +2,10 @@ mod apis;
 mod http;
 mod keys;
 mod ratelimit;
+mod undefined;
 
 pub use apis::*;
 pub use http::*;
 pub use keys::*;
 pub use ratelimit::*;
+pub use undefined::*;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,9 @@
+//! This module houses the types you will be dealing with when sending and
+//! receiving requests from unkey.
+//!
+//! Mostly you will be constructing the structs suffixed with `Request`, and
+//! receiving the structs suffixed with `Response`. With some minor exceptions
+//! like [`Wrapped`] and [`UndefinedOr`].
 mod apis;
 mod http;
 mod keys;

--- a/src/models/undefined.rs
+++ b/src/models/undefined.rs
@@ -21,7 +21,7 @@ impl<T> UndefinedOr<T> {
     ///
     /// # Example
     /// ```
-    /// # use unkey::undefined::UndefinedOr;
+    /// # use unkey::models::UndefinedOr;
     /// let val = UndefinedOr::Value(0);
     ///
     /// assert!(val.is_some());
@@ -34,7 +34,7 @@ impl<T> UndefinedOr<T> {
     ///
     /// # Example
     /// ```
-    /// # use unkey::undefined::UndefinedOr;
+    /// # use unkey::models::UndefinedOr;
     /// let val = UndefinedOr::<u8>::Undefined;
     ///
     /// assert!(val.is_undefined());
@@ -47,7 +47,7 @@ impl<T> UndefinedOr<T> {
     ///
     /// # Example
     /// ```
-    /// # use unkey::undefined::UndefinedOr;
+    /// # use unkey::models::UndefinedOr;
     /// let val = UndefinedOr::<u8>::Null;
     ///
     /// assert!(val.is_null());
@@ -60,7 +60,7 @@ impl<T> UndefinedOr<T> {
     ///
     /// # Example
     /// ```
-    /// # use unkey::undefined::UndefinedOr;
+    /// # use unkey::models::UndefinedOr;
     /// let val = UndefinedOr::Value(420);
     ///
     /// assert_eq!(val.inner(), Some(&420));
@@ -113,7 +113,7 @@ impl<T> From<Option<T>> for UndefinedOr<T> {
 mod test {
     use serde::Serialize;
 
-    use crate::undefined::UndefinedOr;
+    use crate::models::UndefinedOr;
 
     #[derive(Serialize)]
     struct TestStruct {


### PR DESCRIPTION
## Summary

This PR adds more documentation, and moves the `UndefinedOr` enum into the `models` module.

## Checklist

- [x] I have run `cargo test` and all tests pass.
- [x] I have run `cargo fmt` and the code is formatted.
- [x] I have run `cargo clippy` in pedantic mode and refactored.
- [x] I have included documentation for any new structs or methods.
- [x] I have updated tests for any code I addded/changed/deleted.
- [ ] I have updated the CHANGELOG to include my changes.

## Related Issues

N/A
