### PR TITLE
Migrate to new API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+# v0.3.0 (Dec 2023)
+
+## Breaking changes
+
+- `VerifyKeyRequest` now requires an `api_id`.
+- `ListKeysRequest` no longer has an `offset` field.
+
+## Additions
+
+- Add `Conflict` variant to `ErrorCode` enum.
+- Add `get_key` method to `KeyService`.
+- Add `cursor` field to `ListKeysRequest`.
+- Add `Refill`, `RefillInterval`, and `UpdateOp` models/enums.
+- Add `key_id` property onto `ApiKeyVerification`.
+- Add `refill` property onto `ApiKeyMeta` and `ApiKeyVerification`.
+- Add support for `refill` when creating and updating a key.
+- Add `update_remaining` method to `KeyService` and corresponding `Route`.
+
+## Changes
+
+- Refactor internal routes to use new API endpoints.
+- Use new headers requested by Unkey.
+
+---
+
 # v0.2.0 (Sep 2023)
 
 ## Additions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "unkey"
 description = "An asynchronous Rust SDK for the Unkey API."
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Jonxslays"]
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ cargo add unkey
 Add the following to your `Cargo.toml` dependencies array:
 
 ```toml
-unkey = "0.1" # I won't forget to update this™
+unkey = "0.3" # I won't forget to update this™
 ```
 
 ## Examples
@@ -38,7 +38,7 @@ use unkey::Client;
 
 async fn verify_key() {
     let c = Client::new("unkey_ABC");
-    let req = VerifyKeyRequest::new("test_DEF");
+    let req = VerifyKeyRequest::new("test_DEF", "api_JJJ");
 
     match c.verify_key(req).await {
         Wrapped::Ok(res) => println!("{res:?}"),

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,9 @@
+use crate::models::ApiKey;
 use crate::models::CreateKeyRequest;
 use crate::models::CreateKeyResponse;
 use crate::models::GetApiRequest;
 use crate::models::GetApiResponse;
+use crate::models::GetKeyRequest;
 use crate::models::ListKeysRequest;
 use crate::models::ListKeysResponse;
 use crate::models::RevokeKeyRequest;
@@ -122,7 +124,7 @@ impl Client {
     /// # use unkey::models::VerifyKeyRequest;
     /// # use unkey::models::Wrapped;
     /// let c = Client::new("abc123");
-    /// let req = VerifyKeyRequest::new("test_KEYABC");
+    /// let req = VerifyKeyRequest::new("test_KEYABC", "api_123123");
     ///
     /// match c.verify_key(req).await {
     ///     Wrapped::Ok(res) => println!("{:?}", res),
@@ -267,6 +269,33 @@ impl Client {
     /// ````
     pub async fn update_key(&self, req: UpdateKeyRequest) -> Wrapped<()> {
         self.keys.update_key(&self.http, req).await
+    }
+
+    /// Retrieves information for the given api id.
+    ///
+    /// # Arguments
+    /// - `req`: The get api request to send.
+    ///
+    /// # Returns
+    /// A wrapper containing the response, or an [`HttpError`].
+    ///
+    /// # Example
+    /// ```no_run
+    /// # async fn get() {
+    /// # use unkey::Client;
+    /// # use unkey::models::UpdateKeyRequest;
+    /// # use unkey::models::Wrapped;
+    /// let c = Client::new("abc123");
+    /// let req = UpdateKeyRequest::new("api_id").set_remaining(Some(100));
+    ///
+    /// match c.update_key(req).await {
+    ///     Wrapped::Ok(res) => println!("{:?}", res),
+    ///     Wrapped::Err(err) => println!("{:?}", err),
+    /// }
+    /// # }
+    /// ````
+    pub async fn get_key(&self, req: GetKeyRequest) -> Wrapped<ApiKey> {
+        self.keys.get_key(&self.http, req).await
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use models::Wrapped;
 /// The wrapped error.
 macro_rules! response_error {
     ($code:expr, $err:expr) => {
-        crate::models::Wrapped::Err(crate::models::HttpError::new($code, $err.to_string()))
+        $crate::models::Wrapped::Err($crate::models::HttpError::new($code, $err.to_string()))
     };
 }
 

--- a/src/models/apis.rs
+++ b/src/models/apis.rs
@@ -15,8 +15,8 @@ pub struct ListKeysRequest {
     /// The optional number of keys to return, up to 100.
     pub limit: Option<usize>,
 
-    /// The pagination offset.
-    pub offset: Option<usize>,
+    /// The pagination cursor indicating the last key that was returned.
+    pub cursor: Option<String>,
 }
 
 impl ListKeysRequest {
@@ -35,7 +35,7 @@ impl ListKeysRequest {
     ///
     /// assert_eq!(r.api_id, String::from("test"));
     /// assert_eq!(r.limit, None);
-    /// assert_eq!(r.offset, None);
+    /// assert_eq!(r.cursor, None);
     /// assert_eq!(r.owner_id, None);
     /// ```
     #[must_use]
@@ -44,14 +44,14 @@ impl ListKeysRequest {
             api_id: api_id.into(),
             owner_id: None,
             limit: None,
-            offset: None,
+            cursor: None,
         }
     }
 
     /// Sets the limit for the request.
     ///
     /// # Arguments
-    /// - `limit`: The limit to set, defaults to 100.
+    /// - `limit`: The limit to set.
     ///
     /// # Returns
     /// Self for chained calls.
@@ -72,7 +72,7 @@ impl ListKeysRequest {
     /// Sets the pagination offset for the request.
     ///
     /// # Arguments
-    /// - `offset`: The pagination offset to set, defaults to 0.
+    /// - `cursor`: The pagination offset cursor to set.
     ///
     /// # Returns
     /// Self for chained calls.
@@ -80,13 +80,13 @@ impl ListKeysRequest {
     /// # Example
     /// ```
     /// # use unkey::models::ListKeysRequest;
-    /// let r = ListKeysRequest::new("test").set_offset(4);
+    /// let r = ListKeysRequest::new("test").set_cursor("abcabc");
     ///
-    /// assert_eq!(r.offset.unwrap(), 4);
+    /// assert_eq!(r.cursor.unwrap(), String::from("abcabc"));
     /// ```
     #[must_use]
-    pub fn set_offset(mut self, offset: usize) -> Self {
-        self.offset = Some(offset);
+    pub fn set_cursor<T: Into<String>>(mut self, cursor: T) -> Self {
+        self.cursor = Some(cursor.into());
         self
     }
 
@@ -120,6 +120,9 @@ pub struct ListKeysResponse {
 
     /// The total number of api keys.
     pub total: usize,
+
+    /// The cursor indicating the last key that was returned.
+    pub cursor: Option<String>,
 }
 
 /// An outgoing get api request.

--- a/src/models/http.rs
+++ b/src/models/http.rs
@@ -34,6 +34,9 @@ pub enum ErrorCode {
     // The identifier is in use by another resource.
     NotUnique,
 
+    // Another resource already uses this identifier.
+    Conflict,
+
     /// Reserved for unknown interactions.
     #[serde(other)]
     Unknown,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -4,25 +4,31 @@ use reqwest::Method;
 // ROUTES
 ////////////////////////////////////////////////////////////////////////////////
 
-/// The create key endpoint `POST /keys`
-pub(crate) static CREATE_KEY: Route = Route::new(Method::POST, "/keys");
+/// The create key endpoint `POST /keys.createKey`
+pub(crate) static CREATE_KEY: Route = Route::new(Method::POST, "/keys.createKey");
 
-/// The verify key endpoint `POST /keys/verify`
-pub(crate) static VERIFY_KEY: Route = Route::new(Method::POST, "/keys/verify");
+/// The verify key endpoint `POST /keys.verifyKey`
+pub(crate) static VERIFY_KEY: Route = Route::new(Method::POST, "/keys.verifyKey");
 
-/// The delete key endpoint `DELETE /keys/{id}`
-pub(crate) static REVOKE_KEY: Route = Route::new(Method::DELETE, "/keys/{}");
+/// The delete key endpoint `POST /keys.deleteKey`
+pub(crate) static REVOKE_KEY: Route = Route::new(Method::POST, "/keys.deleteKey");
 
-/// The update key endpoint `PUT /keys/{id}`
-pub(crate) static UPDATE_KEY: Route = Route::new(Method::PUT, "/keys/{}");
+/// The update key endpoint `POST /keys.updateKey`
+pub(crate) static UPDATE_KEY: Route = Route::new(Method::POST, "/keys.updateKey");
+
+/// The get key endpoint `GET /keys.getKey`
+pub(crate) static GET_KEY: Route = Route::new(Method::GET, "/keys.getKey");
+
+/// The update remaining endpoint `POST /keys.updateRemaining`
+pub(crate) static UPDATE_REMAINING: Route = Route::new(Method::POST, "/keys.updateRemaining");
 
 ////////////////////////////////////////////////////////////////////////////////
 
-/// The get api endpoint `GET /apis/{id}`
-pub(crate) static GET_API: Route = Route::new(Method::GET, "/apis/{}");
+/// The get api endpoint `GET /apis.getApi`
+pub(crate) static GET_API: Route = Route::new(Method::GET, "/apis.getApi");
 
-/// The list keys endpoint `GET /apis/{id}/keys`
-pub(crate) static LIST_KEYS: Route = Route::new(Method::GET, "/apis/{}/keys");
+/// The list keys endpoint `GET /apis.listKeys`
+pub(crate) static LIST_KEYS: Route = Route::new(Method::GET, "/apis.listKeys");
 
 ////////////////////////////////////////////////////////////////////////////////
 // END ROUTES

--- a/src/services/apis.rs
+++ b/src/services/apis.rs
@@ -31,12 +31,15 @@ impl ApiService {
     ) -> Wrapped<ListKeysResponse> {
         let mut route = routes::LIST_KEYS.compile();
         route
-            .uri_insert(&req.api_id)
-            .query_insert("limit", &req.limit.unwrap_or(100).to_string())
-            .query_insert("offset", &req.offset.unwrap_or(0).to_string());
+            .query_insert("apiId", &req.api_id)
+            .query_insert("limit", &req.limit.unwrap_or(100).to_string());
 
         if let Some(owner) = &req.owner_id {
             route.query_insert("ownerId", owner);
+        }
+
+        if let Some(cursor) = &req.cursor {
+            route.query_insert("cursor", cursor);
         }
 
         wrap_response(fetch!(http, route).await).await
@@ -52,7 +55,7 @@ impl ApiService {
     /// A wrapper around the response, or an [`HttpError`].
     pub async fn get_api(&self, http: &HttpService, req: GetApiRequest) -> Wrapped<GetApiResponse> {
         let mut route = routes::GET_API.compile();
-        route.uri_insert(&req.api_id);
+        route.query_insert("apiId", &req.api_id);
 
         wrap_response(fetch!(http, route).await).await
     }

--- a/src/services/http.rs
+++ b/src/services/http.rs
@@ -71,11 +71,13 @@ impl HttpService {
         let mut headers = HeaderMap::with_capacity(3);
         let key = format!("Bearer {key}");
         let version = env!("CARGO_PKG_VERSION");
-        let user_agent = format!("Unkey Rust SDK v{version}");
+        let user_agent = format!("unkey.rs@v{version}");
 
-        let buffer: [(&'static str, Result<HeaderValue, _>); 3] = [
+        let buffer: [(&'static str, Result<HeaderValue, _>); 5] = [
             ("Accept", HeaderValue::from_str("application/json")),
             ("x-user-agent", HeaderValue::from_str(&user_agent)),
+            ("User-Agent", HeaderValue::from_str(&user_agent)),
+            ("Unkey-SDK", HeaderValue::from_str(&user_agent)),
             ("Authorization", HeaderValue::from_str(&key)),
         ];
 

--- a/src/services/keys.rs
+++ b/src/services/keys.rs
@@ -1,6 +1,8 @@
 use crate::fetch;
+use crate::models::ApiKey;
 use crate::models::CreateKeyRequest;
 use crate::models::CreateKeyResponse;
+use crate::models::GetKeyRequest;
 use crate::models::RevokeKeyRequest;
 use crate::models::UpdateKeyRequest;
 use crate::models::VerifyKeyRequest;
@@ -64,8 +66,7 @@ impl KeyService {
     /// # Returns
     /// A wrapper around an empty response, or an [`HttpError`].
     pub async fn revoke_key(&self, http: &HttpService, req: RevokeKeyRequest) -> Wrapped<()> {
-        let mut route = routes::REVOKE_KEY.compile();
-        route.uri_insert(&req.key_id);
+        let route = routes::REVOKE_KEY.compile();
 
         wrap_empty_response(fetch!(http, route, req).await).await
     }
@@ -79,9 +80,23 @@ impl KeyService {
     /// # Returns
     /// A wrapper around an empty response, or an [`HttpError`].
     pub async fn update_key(&self, http: &HttpService, req: UpdateKeyRequest) -> Wrapped<()> {
-        let mut route = routes::UPDATE_KEY.compile();
-        route.uri_insert(&req.key_id);
+        let route = routes::UPDATE_KEY.compile();
 
         wrap_empty_response(fetch!(http, route, req).await).await
+    }
+
+    /// Updates an existing api key.
+    ///
+    /// # Arguments
+    /// - `http`: The http service to use for the request.
+    /// - `req`: The request to send.
+    ///
+    /// # Returns
+    /// A wrapper around an empty response, or an [`HttpError`].
+    pub async fn get_key(&self, http: &HttpService, req: GetKeyRequest) -> Wrapped<ApiKey> {
+        let mut route = routes::GET_KEY.compile();
+        route.query_insert("keyId", &req.key_id);
+
+        wrap_response(fetch!(http, route, req).await).await
     }
 }


### PR DESCRIPTION
## Summary

Migrates to new RPC style endpoints, adds support for GET KEY.

## Checklist

<!--
- [x] Correct
- [X] Correct
-->

- [x] I have run `cargo test` and all tests pass.
- [x] I have run `cargo fmt` and the code is formatted.
- [x] I have run `cargo clippy` in pedantic mode and refactored.
- [x] I have included documentation for any new structs or methods.
- [x] I have updated tests for any code I addded/changed/deleted.
- [x] I have updated the CHANGELOG to include my changes.

Clippy pedantic gives off 2 warnings but I will address those later.

## Related Issues

Closes #28 
