### PR TITLE
Add support for update remaining and refill

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,16 @@ async fn create_key() {
 ### Updating a key
 
 ```rust
-use unkey::models::{UpdateKeyRequest, Wrapped};
+use unkey::models::{Refill, RefillInterval, UpdateKeyRequest, Wrapped};
 use unkey::Client;
 
 async fn update_key() {
     let c = Client::new("unkey_ABC");
     let req = UpdateKeyRequest::new("key_XYZ")
         .set_name(Some("new_name")) // Update the keys name
-        .set_ratelimit(None); // Remove any ratelimit on the key
+        .set_ratelimit(None) // Remove any ratelimit on the key
+        .set_expires(None) // Remove any expiration date
+        .set_refill(Some(Refill::new(100, RefillInterval::Daily)));
 
     match c.update_key(req).await {
         Wrapped::Ok(res) => println!("{res:?}"),
@@ -132,6 +134,40 @@ async fn get_api() {
     let req = GetApiRequest::new("api_123");
 
     match c.get_api(req).await {
+        Wrapped::Ok(res) => println!("{res:?}"),
+        Wrapped::Err(err) => eprintln!("{err:?}"),
+    }
+}
+```
+
+### Getting key details
+
+```rust
+use unkey::models::{GetKeyRequest, Wrapped};
+use unkey::Client;
+
+async fn get_key() {
+    let c = Client::new("unkey_ABC");
+    let req = GetKeyRequest::new("key_123");
+
+    match c.get_key(req).await {
+        Wrapped::Ok(res) => println!("{res:?}"),
+        Wrapped::Err(err) => eprintln!("{err:?}"),
+    }
+}
+```
+
+### Update remaining verifications
+
+```rust
+use unkey::models::{UpdateOp, UpdateRemainingRequest, Wrapped};
+use unkey::Client;
+
+async fn update_remaining() {
+    let c = Client::new("unkey_ABC");
+    let req = UpdateRemainingRequest::new("key_123", Some(100), UpdateOp::Set);
+
+    match c.update_remaining(req).await {
         Wrapped::Ok(res) => println!("{res:?}"),
         Wrapped::Err(err) => eprintln!("{err:?}"),
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,6 +8,8 @@ use crate::models::ListKeysRequest;
 use crate::models::ListKeysResponse;
 use crate::models::RevokeKeyRequest;
 use crate::models::UpdateKeyRequest;
+use crate::models::UpdateRemainingRequest;
+use crate::models::UpdateRemainingResponse;
 use crate::models::VerifyKeyRequest;
 use crate::models::VerifyKeyResponse;
 use crate::models::Wrapped;
@@ -274,7 +276,7 @@ impl Client {
     /// Retrieves information for the given api id.
     ///
     /// # Arguments
-    /// - `req`: The get api request to send.
+    /// - `req`: The get key request to send.
     ///
     /// # Returns
     /// A wrapper containing the response, or an [`HttpError`].
@@ -283,12 +285,12 @@ impl Client {
     /// ```no_run
     /// # async fn get() {
     /// # use unkey::Client;
-    /// # use unkey::models::UpdateKeyRequest;
+    /// # use unkey::models::GetKeyRequest;
     /// # use unkey::models::Wrapped;
     /// let c = Client::new("abc123");
-    /// let req = UpdateKeyRequest::new("api_id").set_remaining(Some(100));
+    /// let req = GetKeyRequest::new("api_id");
     ///
-    /// match c.update_key(req).await {
+    /// match c.get_key(req).await {
     ///     Wrapped::Ok(res) => println!("{:?}", res),
     ///     Wrapped::Err(err) => println!("{:?}", err),
     /// }
@@ -296,6 +298,37 @@ impl Client {
     /// ````
     pub async fn get_key(&self, req: GetKeyRequest) -> Wrapped<ApiKey> {
         self.keys.get_key(&self.http, req).await
+    }
+
+    /// Update the remaining verifications for a key.
+    ///
+    /// # Arguments
+    /// - `req`: The update remaining request to send.
+    ///
+    /// # Returns
+    /// A wrapper containing the response, or an [`HttpError`].
+    ///
+    /// # Example
+    /// ```no_run
+    /// # async fn get() {
+    /// # use unkey::Client;
+    /// # use unkey::models::UpdateRemainingRequest;
+    /// # use unkey::models::UpdateOp;
+    /// # use unkey::models::Wrapped;
+    /// let c = Client::new("abc123");
+    /// let req = UpdateRemainingRequest::new("api_id", Some(100), UpdateOp::Set);
+    ///
+    /// match c.update_remaining(req).await {
+    ///     Wrapped::Ok(res) => println!("{:?}", res),
+    ///     Wrapped::Err(err) => println!("{:?}", err),
+    /// }
+    /// # }
+    /// ````
+    pub async fn update_remaining(
+        &self,
+        req: UpdateRemainingRequest,
+    ) -> Wrapped<UpdateRemainingResponse> {
+        self.keys.update_remaining(&self.http, req).await
     }
 }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -8,10 +8,12 @@ mod apis;
 mod http;
 mod keys;
 mod ratelimit;
+mod refill;
 mod undefined;
 
 pub use apis::*;
 pub use http::*;
 pub use keys::*;
 pub use ratelimit::*;
+pub use refill::*;
 pub use undefined::*;

--- a/src/models/refill.rs
+++ b/src/models/refill.rs
@@ -1,0 +1,57 @@
+#![allow(clippy::module_name_repetitions)]
+
+use serde::Deserialize;
+use serde::Serialize;
+
+/// An update operation that can be performed.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum RefillInterval {
+    /// Refill daily.
+    Daily,
+
+    /// Refill monthly.
+    Monthly,
+}
+
+/// The state of a keys automatic refills.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Refill {
+    /// The number of verifications to refill.
+    pub amount: usize,
+
+    /// The interval at which to refill the verifications.
+    pub interval: RefillInterval,
+
+    /// The UNIX timestamp in milliseconds indicating when the key was last
+    /// refilled, if it has been.
+    #[serde(skip_serializing)]
+    pub last_refilled_at: Option<usize>,
+}
+
+impl Refill {
+    /// Creates a new refill.
+    ///
+    /// # Arguments
+    /// - `amount`: The number of verifications to refill.
+    /// - `interval`: The interval at which to refill the verifications.
+    ///
+    /// # Returns
+    /// The refill struct.
+    ///
+    /// # Example
+    /// ```
+    /// # use unkey::models::Refill;
+    /// # use unkey::models::RefillInterval;
+    /// let r = Refill::new(100, RefillInterval::Daily);
+    ///
+    /// assert_eq!(r.amount, 100);
+    /// assert_eq!(r.interval, RefillInterval::Daily);
+    /// ```
+    #[must_use]
+    #[rustfmt::skip]
+    pub fn new(amount: usize, interval: RefillInterval) -> Self {
+        Self { amount, interval, last_refilled_at: None }
+    }
+}

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -109,6 +109,7 @@ impl CompiledRoute {
     ///
     /// # Returns
     /// Self for chained calls.
+    #[allow(dead_code)] // Was used in the past, any may again in the future
     pub fn uri_insert<T: Into<String>>(&mut self, param: T) -> &mut Self {
         self.uri = self.uri.replacen("{}", &param.into(), 1);
         self

--- a/src/services/keys.rs
+++ b/src/services/keys.rs
@@ -5,6 +5,8 @@ use crate::models::CreateKeyResponse;
 use crate::models::GetKeyRequest;
 use crate::models::RevokeKeyRequest;
 use crate::models::UpdateKeyRequest;
+use crate::models::UpdateRemainingRequest;
+use crate::models::UpdateRemainingResponse;
 use crate::models::VerifyKeyRequest;
 use crate::models::VerifyKeyResponse;
 use crate::models::Wrapped;
@@ -85,17 +87,35 @@ impl KeyService {
         wrap_empty_response(fetch!(http, route, req).await).await
     }
 
-    /// Updates an existing api key.
+    /// Gets details about an api key.
     ///
     /// # Arguments
     /// - `http`: The http service to use for the request.
     /// - `req`: The request to send.
     ///
     /// # Returns
-    /// A wrapper around an empty response, or an [`HttpError`].
+    /// A wrapper around the response, or an [`HttpError`].
     pub async fn get_key(&self, http: &HttpService, req: GetKeyRequest) -> Wrapped<ApiKey> {
         let mut route = routes::GET_KEY.compile();
         route.query_insert("keyId", &req.key_id);
+
+        wrap_response(fetch!(http, route).await).await
+    }
+
+    /// Updates the remaining verifications for a key.
+    ///
+    /// # Arguments
+    /// - `http`: The http service to use for the request.
+    /// - `req`: The request to send.
+    ///
+    /// # Returns
+    /// A wrapper around the response, or an [`HttpError`].
+    pub async fn update_remaining(
+        &self,
+        http: &HttpService,
+        req: UpdateRemainingRequest,
+    ) -> Wrapped<UpdateRemainingResponse> {
+        let route = routes::UPDATE_REMAINING.compile();
 
         wrap_response(fetch!(http, route, req).await).await
     }


### PR DESCRIPTION
## Summary

Adds support for GET /keys.updateRemaining, and the refill property when creating and updating a key.

## Checklist

<!--
- [x] Correct
- [X] Correct
-->

- [x] I have run `cargo test` and all tests pass.
- [x] I have run `cargo fmt` and the code is formatted.
- [x] I have run `cargo clippy` in pedantic mode and refactored.
- [x] I have included documentation for any new structs or methods.
- [x] I have updated tests for any code I addded/changed/deleted.
- [x] I have updated the CHANGELOG to include my changes.

## Related Issues

Closes #29 
