### PR TITLE
Use Result in place of Wrapped in the public api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v0.4.0 (Jul 2024)
+
+## Breaking changes
+
+- All async `Client` methods now return a `Result` instead of `Wrapped`.
+
+## Additions
+
+- `Result<T, HttpErrorResponse>` now implements `From<Wrapped<T>>`.
+
+---
+
 # v0.3.0 (Dec 2023)
 
 ## Breaking changes
@@ -32,6 +44,8 @@
 ## Changes
 
 - Rename `UsageExceeded` error code to `KeyUsageExceeded`.
+
+---
 
 # v0.1.0 (Aug 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Breaking changes
 
-- All async `Client` methods now return a `Result` instead of `Wrapped`.
+- All async `Client` methods and service methods now return a `Result` instead of `Wrapped`.
+- Wrapped is now `pub(crate)` and considered internal implementation detail.
 
 ## Additions
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "unkey"
 description = "An asynchronous Rust SDK for the Unkey API."
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Jonxslays"]
 readme = "README.md"
@@ -24,4 +24,4 @@ serde_json = "1"
 [dependencies.reqwest]
 version = "0.11"
 features = ["json", "rustls-tls"]
-default_features = false
+default-features = false

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ All the API key management features you love, now with more type safety!
 
 ## MSRV
 
-The minimum supported Rust verision for the project is `1.63.0`.
+The minimum supported Rust version for the project is `1.63.0`.
 
 ## Documentation
 
@@ -17,7 +17,7 @@ Full documentation can be found at [https://docs.rs/unkey](https://docs.rs/unkey
 ### Using `cargo`
 
 ```bash
-$ cargo add unkey
+cargo add unkey
 ```
 
 ### Manually
@@ -33,7 +33,7 @@ unkey = "0.3" # I won't forget to update this™
 ### Verifying a key
 
 ```rust
-use unkey::models::{VerifyKeyRequest, Wrapped};
+use unkey::models::VerifyKeyRequest;
 use unkey::Client;
 
 async fn verify_key() {
@@ -41,8 +41,8 @@ async fn verify_key() {
     let req = VerifyKeyRequest::new("test_DEF", "api_JJJ");
 
     match c.verify_key(req).await {
-        Wrapped::Ok(res) => println!("{res:?}"),
-        Wrapped::Err(err) => eprintln!("{err:?}"),
+        Ok(res) => println!("{res:?}"),
+        Err(err) => eprintln!("{err:?}"),
     }
 }
 ```
@@ -50,7 +50,7 @@ async fn verify_key() {
 ### Creating a key
 
 ```rust
-use unkey::models::{CreateKeyRequest, Wrapped};
+use unkey::models::CreateKeyRequest;
 use unkey::Client;
 
 async fn create_key() {
@@ -62,8 +62,8 @@ async fn create_key() {
         .set_owner_id("jonxslays");
 
     match c.create_key(req).await {
-        Wrapped::Ok(res) => println!("{res:?}"),
-        Wrapped::Err(err) => eprintln!("{err:?}"),
+        Ok(res) => println!("{res:?}"),
+        Err(err) => eprintln!("{err:?}"),
     }
 }
 ```
@@ -71,7 +71,7 @@ async fn create_key() {
 ### Updating a key
 
 ```rust
-use unkey::models::{Refill, RefillInterval, UpdateKeyRequest, Wrapped};
+use unkey::models::{Refill, RefillInterval, UpdateKeyRequest};
 use unkey::Client;
 
 async fn update_key() {
@@ -83,8 +83,8 @@ async fn update_key() {
         .set_refill(Some(Refill::new(100, RefillInterval::Daily)));
 
     match c.update_key(req).await {
-        Wrapped::Ok(res) => println!("{res:?}"),
-        Wrapped::Err(err) => eprintln!("{err:?}"),
+        Ok(res) => println!("{res:?}"),
+        Err(err) => eprintln!("{err:?}"),
     }
 }
 ```
@@ -92,7 +92,7 @@ async fn update_key() {
 ### Revoking a key
 
 ```rust
-use unkey::models::{RevokeKeyRequest, Wrapped};
+use unkey::models::RevokeKeyRequest;
 use unkey::Client;
 
 async fn revoke_key() {
@@ -100,8 +100,8 @@ async fn revoke_key() {
     let req = RevokeKeyRequest::new("key_XYZ");
 
     match c.revoke_key(req).await {
-        Wrapped::Ok(res) => println!("{res:?}"),
-        Wrapped::Err(err) => eprintln!("{err:?}"),
+        Ok(res) => println!("{res:?}"),
+        Err(err) => eprintln!("{err:?}"),
     }
 }
 ```
@@ -109,7 +109,7 @@ async fn revoke_key() {
 ### Listing api keys
 
 ```rust
-use unkey::models::{ListKeysRequest, Wrapped};
+use unkey::models::ListKeysRequest;
 use unkey::Client;
 
 async fn list_keys() {
@@ -117,8 +117,8 @@ async fn list_keys() {
     let req = ListKeysRequest::new("api_123");
 
     match c.list_keys(req).await {
-        Wrapped::Ok(res) => println!("{res:?}"),
-        Wrapped::Err(err) => eprintln!("{err:?}"),
+        Ok(res) => println!("{res:?}"),
+        Err(err) => eprintln!("{err:?}"),
     }
 }
 ```
@@ -126,7 +126,7 @@ async fn list_keys() {
 ### Getting api information
 
 ```rust
-use unkey::models::{GetApiRequest, Wrapped};
+use unkey::models::GetApiRequest;
 use unkey::Client;
 
 async fn get_api() {
@@ -134,8 +134,8 @@ async fn get_api() {
     let req = GetApiRequest::new("api_123");
 
     match c.get_api(req).await {
-        Wrapped::Ok(res) => println!("{res:?}"),
-        Wrapped::Err(err) => eprintln!("{err:?}"),
+        Ok(res) => println!("{res:?}"),
+        Err(err) => eprintln!("{err:?}"),
     }
 }
 ```
@@ -143,7 +143,7 @@ async fn get_api() {
 ### Getting key details
 
 ```rust
-use unkey::models::{GetKeyRequest, Wrapped};
+use unkey::models::GetKeyRequest;
 use unkey::Client;
 
 async fn get_key() {
@@ -151,8 +151,8 @@ async fn get_key() {
     let req = GetKeyRequest::new("key_123");
 
     match c.get_key(req).await {
-        Wrapped::Ok(res) => println!("{res:?}"),
-        Wrapped::Err(err) => eprintln!("{err:?}"),
+        Ok(res) => println!("{res:?}"),
+        Err(err) => eprintln!("{err:?}"),
     }
 }
 ```
@@ -160,7 +160,7 @@ async fn get_key() {
 ### Update remaining verifications
 
 ```rust
-use unkey::models::{UpdateOp, UpdateRemainingRequest, Wrapped};
+use unkey::models::{UpdateOp, UpdateRemainingRequest};
 use unkey::Client;
 
 async fn update_remaining() {
@@ -168,8 +168,8 @@ async fn update_remaining() {
     let req = UpdateRemainingRequest::new("key_123", Some(100), UpdateOp::Set);
 
     match c.update_remaining(req).await {
-        Wrapped::Ok(res) => println!("{res:?}"),
-        Wrapped::Err(err) => eprintln!("{err:?}"),
+        Ok(res) => println!("{res:?}"),
+        Err(err) => eprintln!("{err:?}"),
     }
 }
 ```

--- a/src/client.rs
+++ b/src/client.rs
@@ -136,7 +136,7 @@ impl Client {
     /// # }
     /// ```
     pub async fn verify_key(&self, req: VerifyKeyRequest) -> Result<VerifyKeyResponse, HttpError> {
-        self.keys.verify_key(&self.http, req).await.into()
+        self.keys.verify_key(&self.http, req).await
     }
 
     /// Creates a new api key.
@@ -165,7 +165,7 @@ impl Client {
     /// # }
     /// ```
     pub async fn create_key(&self, req: CreateKeyRequest) -> Result<CreateKeyResponse, HttpError> {
-        self.keys.create_key(&self.http, req).await.into()
+        self.keys.create_key(&self.http, req).await
     }
 
     /// Retrieves a paginated list of api keys.
@@ -194,7 +194,7 @@ impl Client {
     /// # }
     /// ```
     pub async fn list_keys(&self, req: ListKeysRequest) -> Result<ListKeysResponse, HttpError> {
-        self.apis.list_keys(&self.http, req).await.into()
+        self.apis.list_keys(&self.http, req).await
     }
 
     /// Revokes an existing api key.
@@ -223,7 +223,7 @@ impl Client {
     /// # }
     /// ```
     pub async fn revoke_key(&self, req: RevokeKeyRequest) -> Result<(), HttpError> {
-        self.keys.revoke_key(&self.http, req).await.into()
+        self.keys.revoke_key(&self.http, req).await
     }
 
     /// Retrieves information for the given api id.
@@ -252,7 +252,7 @@ impl Client {
     /// # }
     /// ````
     pub async fn get_api(&self, req: GetApiRequest) -> Result<GetApiResponse, HttpError> {
-        self.apis.get_api(&self.http, req).await.into()
+        self.apis.get_api(&self.http, req).await
     }
 
     /// Retrieves information for the given api id.
@@ -281,7 +281,7 @@ impl Client {
     /// # }
     /// ````
     pub async fn update_key(&self, req: UpdateKeyRequest) -> Result<(), HttpError> {
-        self.keys.update_key(&self.http, req).await.into()
+        self.keys.update_key(&self.http, req).await
     }
 
     /// Retrieves information for the given api id.
@@ -310,7 +310,7 @@ impl Client {
     /// # }
     /// ````
     pub async fn get_key(&self, req: GetKeyRequest) -> Result<ApiKey, HttpError> {
-        self.keys.get_key(&self.http, req).await.into()
+        self.keys.get_key(&self.http, req).await
     }
 
     /// Update the remaining verifications for a key.
@@ -343,7 +343,7 @@ impl Client {
         &self,
         req: UpdateRemainingRequest,
     ) -> Result<UpdateRemainingResponse, HttpError> {
-        self.keys.update_remaining(&self.http, req).await.into()
+        self.keys.update_remaining(&self.http, req).await
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,7 +12,6 @@ use crate::models::UpdateRemainingRequest;
 use crate::models::UpdateRemainingResponse;
 use crate::models::VerifyKeyRequest;
 use crate::models::VerifyKeyResponse;
-use crate::models::Wrapped;
 use crate::services::ApiService;
 use crate::services::HttpService;
 use crate::services::KeyService;
@@ -117,25 +116,27 @@ impl Client {
     /// - `req`: The verify key request to send.
     ///
     /// # Returns
-    /// A wrapper containing the response, or an [`HttpError`].
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
     ///
     /// # Example
     /// ```no_run
     /// # async fn verify() {
     /// # use unkey::Client;
     /// # use unkey::models::VerifyKeyRequest;
-    /// # use unkey::models::Wrapped;
     /// let c = Client::new("abc123");
     /// let req = VerifyKeyRequest::new("test_KEYABC", "api_123123");
     ///
     /// match c.verify_key(req).await {
-    ///     Wrapped::Ok(res) => println!("{:?}", res),
-    ///     Wrapped::Err(err) => println!("{:?}", err),
+    ///     Ok(res) => println!("{:?}", res),
+    ///     Err(err) => println!("{:?}", err),
     /// }
     /// # }
     /// ```
-    pub async fn verify_key(&self, req: VerifyKeyRequest) -> Wrapped<VerifyKeyResponse> {
-        self.keys.verify_key(&self.http, req).await
+    pub async fn verify_key(&self, req: VerifyKeyRequest) -> Result<VerifyKeyResponse, HttpError> {
+        self.keys.verify_key(&self.http, req).await.into()
     }
 
     /// Creates a new api key.
@@ -144,25 +145,27 @@ impl Client {
     /// - `req`: The create key request to send.
     ///
     /// # Returns
-    /// A wrapper containing the response, or an [`HttpError`].
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
     ///
     /// # Example
     /// ```no_run
     /// # async fn create() {
     /// # use unkey::Client;
     /// # use unkey::models::CreateKeyRequest;
-    /// # use unkey::models::Wrapped;
     /// let c = Client::new("abc123");
     /// let req = CreateKeyRequest::new("api_CCC").set_remaining(100);
     ///
     /// match c.create_key(req).await {
-    ///     Wrapped::Ok(res) => println!("{:?}", res),
-    ///     Wrapped::Err(err) => println!("{:?}", err),
+    ///     Ok(res) => println!("{:?}", res),
+    ///     Err(err) => println!("{:?}", err),
     /// }
     /// # }
     /// ```
-    pub async fn create_key(&self, req: CreateKeyRequest) -> Wrapped<CreateKeyResponse> {
-        self.keys.create_key(&self.http, req).await
+    pub async fn create_key(&self, req: CreateKeyRequest) -> Result<CreateKeyResponse, HttpError> {
+        self.keys.create_key(&self.http, req).await.into()
     }
 
     /// Retrieves a paginated list of api keys.
@@ -171,25 +174,27 @@ impl Client {
     /// - `req`: The list keys request to send.
     ///
     /// # Returns
-    /// A wrapper containing the response, or an [`HttpError`].
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
     ///
     /// # Example
     /// ```no_run
     /// # async fn list() {
     /// # use unkey::Client;
     /// # use unkey::models::ListKeysRequest;
-    /// # use unkey::models::Wrapped;
     /// let c = Client::new("abc123");
     /// let req = ListKeysRequest::new("api_id").set_limit(25);
     ///
     /// match c.list_keys(req).await {
-    ///     Wrapped::Ok(res) => println!("{:?}", res),
-    ///     Wrapped::Err(err) => println!("{:?}", err),
+    ///     Ok(res) => println!("{:?}", res),
+    ///     Err(err) => println!("{:?}", err),
     /// }
     /// # }
     /// ```
-    pub async fn list_keys(&self, req: ListKeysRequest) -> Wrapped<ListKeysResponse> {
-        self.apis.list_keys(&self.http, req).await
+    pub async fn list_keys(&self, req: ListKeysRequest) -> Result<ListKeysResponse, HttpError> {
+        self.apis.list_keys(&self.http, req).await.into()
     }
 
     /// Revokes an existing api key.
@@ -198,25 +203,27 @@ impl Client {
     /// - `req`: The revoke key request to send.
     ///
     /// # Returns
-    /// A wrapper containing the empty response, or an [`HttpError`].
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
     ///
     /// # Example
     /// ```no_run
     /// # async fn revoke() {
     /// # use unkey::Client;
     /// # use unkey::models::RevokeKeyRequest;
-    /// # use unkey::models::Wrapped;
     /// let c = Client::new("abc123");
     /// let req = RevokeKeyRequest::new("test_123");
     ///
     /// match c.revoke_key(req).await {
-    ///     Wrapped::Ok(_) => println!("Success!"), // Nothing on success
-    ///     Wrapped::Err(err) => println!("{:?}", err),
+    ///     Ok(_) => println!("Success!"), // Nothing on success
+    ///     Err(err) => println!("{:?}", err),
     /// }
     /// # }
     /// ```
-    pub async fn revoke_key(&self, req: RevokeKeyRequest) -> Wrapped<()> {
-        self.keys.revoke_key(&self.http, req).await
+    pub async fn revoke_key(&self, req: RevokeKeyRequest) -> Result<(), HttpError> {
+        self.keys.revoke_key(&self.http, req).await.into()
     }
 
     /// Retrieves information for the given api id.
@@ -225,25 +232,27 @@ impl Client {
     /// - `req`: The get api request to send.
     ///
     /// # Returns
-    /// A wrapper containing the response, or an [`HttpError`].
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
     ///
     /// # Example
     /// ```no_run
     /// # async fn get() {
     /// # use unkey::Client;
     /// # use unkey::models::GetApiRequest;
-    /// # use unkey::models::Wrapped;
     /// let c = Client::new("abc123");
     /// let req = GetApiRequest::new("api_id");
     ///
     /// match c.get_api(req).await {
-    ///     Wrapped::Ok(res) => println!("{:?}", res),
-    ///     Wrapped::Err(err) => println!("{:?}", err),
+    ///     Ok(res) => println!("{:?}", res),
+    ///     Err(err) => println!("{:?}", err),
     /// }
     /// # }
     /// ````
-    pub async fn get_api(&self, req: GetApiRequest) -> Wrapped<GetApiResponse> {
-        self.apis.get_api(&self.http, req).await
+    pub async fn get_api(&self, req: GetApiRequest) -> Result<GetApiResponse, HttpError> {
+        self.apis.get_api(&self.http, req).await.into()
     }
 
     /// Retrieves information for the given api id.
@@ -252,25 +261,27 @@ impl Client {
     /// - `req`: The get api request to send.
     ///
     /// # Returns
-    /// A wrapper containing the response, or an [`HttpError`].
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
     ///
     /// # Example
     /// ```no_run
     /// # async fn get() {
     /// # use unkey::Client;
     /// # use unkey::models::UpdateKeyRequest;
-    /// # use unkey::models::Wrapped;
     /// let c = Client::new("abc123");
     /// let req = UpdateKeyRequest::new("api_id").set_remaining(Some(100));
     ///
     /// match c.update_key(req).await {
-    ///     Wrapped::Ok(res) => println!("{:?}", res),
-    ///     Wrapped::Err(err) => println!("{:?}", err),
+    ///     Ok(res) => println!("{:?}", res),
+    ///     Err(err) => println!("{:?}", err),
     /// }
     /// # }
     /// ````
-    pub async fn update_key(&self, req: UpdateKeyRequest) -> Wrapped<()> {
-        self.keys.update_key(&self.http, req).await
+    pub async fn update_key(&self, req: UpdateKeyRequest) -> Result<(), HttpError> {
+        self.keys.update_key(&self.http, req).await.into()
     }
 
     /// Retrieves information for the given api id.
@@ -279,25 +290,27 @@ impl Client {
     /// - `req`: The get key request to send.
     ///
     /// # Returns
-    /// A wrapper containing the response, or an [`HttpError`].
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
     ///
     /// # Example
     /// ```no_run
     /// # async fn get() {
     /// # use unkey::Client;
     /// # use unkey::models::GetKeyRequest;
-    /// # use unkey::models::Wrapped;
     /// let c = Client::new("abc123");
-    /// let req = GetKeyRequest::new("api_id");
+    /// let req = GetKeyRequest::new("key_id");
     ///
     /// match c.get_key(req).await {
-    ///     Wrapped::Ok(res) => println!("{:?}", res),
-    ///     Wrapped::Err(err) => println!("{:?}", err),
+    ///     Ok(res) => println!("{:?}", res),
+    ///     Err(err) => println!("{:?}", err),
     /// }
     /// # }
     /// ````
-    pub async fn get_key(&self, req: GetKeyRequest) -> Wrapped<ApiKey> {
-        self.keys.get_key(&self.http, req).await
+    pub async fn get_key(&self, req: GetKeyRequest) -> Result<ApiKey, HttpError> {
+        self.keys.get_key(&self.http, req).await.into()
     }
 
     /// Update the remaining verifications for a key.
@@ -306,7 +319,10 @@ impl Client {
     /// - `req`: The update remaining request to send.
     ///
     /// # Returns
-    /// A wrapper containing the response, or an [`HttpError`].
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
     ///
     /// # Example
     /// ```no_run
@@ -314,21 +330,20 @@ impl Client {
     /// # use unkey::Client;
     /// # use unkey::models::UpdateRemainingRequest;
     /// # use unkey::models::UpdateOp;
-    /// # use unkey::models::Wrapped;
     /// let c = Client::new("abc123");
-    /// let req = UpdateRemainingRequest::new("api_id", Some(100), UpdateOp::Set);
+    /// let req = UpdateRemainingRequest::new("key_id", Some(100), UpdateOp::Set);
     ///
     /// match c.update_remaining(req).await {
-    ///     Wrapped::Ok(res) => println!("{:?}", res),
-    ///     Wrapped::Err(err) => println!("{:?}", err),
+    ///     Ok(res) => println!("{:?}", res),
+    ///     Err(err) => println!("{:?}", err),
     /// }
     /// # }
     /// ````
     pub async fn update_remaining(
         &self,
         req: UpdateRemainingRequest,
-    ) -> Wrapped<UpdateRemainingResponse> {
-        self.keys.update_remaining(&self.http, req).await
+    ) -> Result<UpdateRemainingResponse, HttpError> {
+        self.keys.update_remaining(&self.http, req).await.into()
     }
 }
 
@@ -345,7 +360,4 @@ mod test {
         assert_eq!(c.apis, ApiService);
         assert_eq!(c.keys, KeyService);
     }
-
-    // TODO: Write a custom API to run for integration tests with the client.
-    // It will be the clients base URL for testing requests.
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use models::ErrorCode;
 use models::HttpResult;
 use models::Wrapped;
 
-/// Creates a new Err variant of [`Response`].
+/// Creates a new Err variant of [`Wrapped`].
 ///
 /// # Arguments
 /// - `$code`: The [`ErrorCode`] for the error.
@@ -98,7 +98,7 @@ pub(crate) async fn wrap_empty_response(result: HttpResult) -> Wrapped<()> {
     }
 }
 
-/// Fetchs the given route with the provided http service.
+/// Fetches the given route with the provided http service.
 macro_rules! fetch {
     ($http:expr, $route:ident) => {
         $http.fetch($route, None::<u8>)
@@ -130,7 +130,7 @@ mod test {
     }
 
     #[test]
-    fn reponse_error() {
+    fn response_error() {
         let res: Wrapped<()> = response_error!(ErrorCode::NotFound, "not found!");
 
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod models;
 mod routes;
 mod services;
 
+use models::HttpError;
 use serde::Deserialize;
 
 pub use client::Client;
@@ -23,18 +24,21 @@ use models::Wrapped;
 /// The wrapped error.
 macro_rules! response_error {
     ($code:expr, $err:expr) => {
-        $crate::models::Wrapped::Err($crate::models::HttpError::new($code, $err.to_string()))
+        ::std::result::Result::Err($crate::models::HttpError::new($code, $err.to_string()))
     };
 }
 
-/// Wraps the http result.
+/// Parses the http result.
 ///
 /// # Arguments
 /// - `result`: The http result from the request.
 ///
 /// # Returns
-/// The wrapped response or an error.
-pub(crate) async fn wrap_response<T>(result: HttpResult) -> Wrapped<T>
+/// A [`Result`] containing the response, or an error.
+///
+/// # Errors
+/// The [`HttpError`], if one occurred.
+pub(crate) async fn parse_response<T>(result: HttpResult) -> Result<T, HttpError>
 where
     T: for<'a> Deserialize<'a>,
 {
@@ -53,7 +57,7 @@ where
 
             match serde_json::from_str::<Wrapped<T>>(&text) {
                 Err(e) => response_error!(ErrorCode::Unknown, e),
-                Ok(r) => r,
+                Ok(r) => r.into(),
             }
         }
     }
@@ -65,8 +69,11 @@ where
 /// - `result`: The http result from the request.
 ///
 /// # Returns
-/// The wrapped response or an error.
-pub(crate) async fn wrap_empty_response(result: HttpResult) -> Wrapped<()> {
+/// A [`Result`] containing the response, or an error.
+///
+/// # Errors
+/// The [`HttpError`], if one occurred.
+pub(crate) async fn parse_empty_response(result: HttpResult) -> Result<(), HttpError> {
     let data = match result {
         Ok(r) => r.text().await,
         Err(e) => {
@@ -81,7 +88,7 @@ pub(crate) async fn wrap_empty_response(result: HttpResult) -> Wrapped<()> {
             logging::debug!(format!("INCOMING: {text}"));
 
             match serde_json::from_str::<Wrapped<()>>(&text) {
-                Ok(r) => r,
+                Ok(r) => r.into(),
                 Err(e) => {
                     if text.contains("error") {
                         // If the text contains error and we failed to deserialize
@@ -90,7 +97,7 @@ pub(crate) async fn wrap_empty_response(result: HttpResult) -> Wrapped<()> {
                     } else {
                         // Otherwise it was successful even though we are in Err
                         // due to serde failing to deserialize a unit type
-                        Wrapped::Ok(())
+                        Ok(())
                     }
                 }
             }
@@ -114,7 +121,6 @@ pub(crate) use fetch;
 mod test {
     use crate::models::ErrorCode;
     use crate::models::HttpError;
-    use crate::models::Wrapped;
 
     struct FakeHttp;
 
@@ -131,11 +137,11 @@ mod test {
 
     #[test]
     fn response_error() {
-        let res: Wrapped<()> = response_error!(ErrorCode::NotFound, "not found!");
+        let res: Result<(), _> = response_error!(ErrorCode::NotFound, "not found!");
 
         assert_eq!(
             res,
-            Wrapped::Err(HttpError::new(
+            Err(HttpError::new(
                 ErrorCode::NotFound,
                 String::from("not found!")
             ))

--- a/src/models/http.rs
+++ b/src/models/http.rs
@@ -84,7 +84,7 @@ impl HttpError {
 /// A wrapper around the response type or an error.
 #[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
 #[must_use = "this `Wrapped` result may be an `Err` variant, which should be handled"]
-pub enum Wrapped<T> {
+pub(crate) enum Wrapped<T> {
     /// The error value.
     #[serde(rename = "error")]
     Err(HttpError),

--- a/src/services/apis.rs
+++ b/src/services/apis.rs
@@ -3,10 +3,9 @@ use crate::models::GetApiRequest;
 use crate::models::GetApiResponse;
 use crate::models::ListKeysRequest;
 use crate::models::ListKeysResponse;
-use crate::models::Wrapped;
+use crate::parse_response;
 use crate::routes;
 use crate::services::HttpService;
-use crate::wrap_response;
 
 #[allow(unused_imports)]
 use crate::models::HttpError;
@@ -23,12 +22,15 @@ impl ApiService {
     /// - `req`: The request to send.
     ///
     /// # Returns
-    /// A wrapper around the response, or an [`HttpError`].
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
     pub async fn list_keys(
         &self,
         http: &HttpService,
         req: ListKeysRequest,
-    ) -> Wrapped<ListKeysResponse> {
+    ) -> Result<ListKeysResponse, HttpError> {
         let mut route = routes::LIST_KEYS.compile();
         route
             .query_insert("apiId", &req.api_id)
@@ -42,7 +44,7 @@ impl ApiService {
             route.query_insert("cursor", cursor);
         }
 
-        wrap_response(fetch!(http, route).await).await
+        parse_response(fetch!(http, route).await).await
     }
 
     /// Retrieves api information.
@@ -52,11 +54,18 @@ impl ApiService {
     /// - `req`: The request to send.
     ///
     /// # Returns
-    /// A wrapper around the response, or an [`HttpError`].
-    pub async fn get_api(&self, http: &HttpService, req: GetApiRequest) -> Wrapped<GetApiResponse> {
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
+    pub async fn get_api(
+        &self,
+        http: &HttpService,
+        req: GetApiRequest,
+    ) -> Result<GetApiResponse, HttpError> {
         let mut route = routes::GET_API.compile();
         route.query_insert("apiId", &req.api_id);
 
-        wrap_response(fetch!(http, route).await).await
+        parse_response(fetch!(http, route).await).await
     }
 }

--- a/src/services/keys.rs
+++ b/src/services/keys.rs
@@ -9,11 +9,10 @@ use crate::models::UpdateRemainingRequest;
 use crate::models::UpdateRemainingResponse;
 use crate::models::VerifyKeyRequest;
 use crate::models::VerifyKeyResponse;
-use crate::models::Wrapped;
+use crate::parse_empty_response;
+use crate::parse_response;
 use crate::routes;
 use crate::services::HttpService;
-use crate::wrap_empty_response;
-use crate::wrap_response;
 
 #[allow(unused_imports)]
 use crate::models::HttpError;
@@ -30,15 +29,18 @@ impl KeyService {
     /// - `req`: The request to send.
     ///
     /// # Returns
-    /// A wrapper around the response, or an [`HttpError`].
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
     pub async fn create_key(
         &self,
         http: &HttpService,
         req: CreateKeyRequest,
-    ) -> Wrapped<CreateKeyResponse> {
+    ) -> Result<CreateKeyResponse, HttpError> {
         let route = routes::CREATE_KEY.compile();
 
-        wrap_response(fetch!(http, route, req).await).await
+        parse_response(fetch!(http, route, req).await).await
     }
 
     /// Verifies an existing api key.
@@ -48,15 +50,18 @@ impl KeyService {
     /// - `req`: The request to send.
     ///
     /// # Returns
-    /// A wrapper around the response, or an [`HttpError`].
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
     pub async fn verify_key(
         &self,
         http: &HttpService,
         req: VerifyKeyRequest,
-    ) -> Wrapped<VerifyKeyResponse> {
+    ) -> Result<VerifyKeyResponse, HttpError> {
         let route = routes::VERIFY_KEY.compile();
 
-        wrap_response(fetch!(http, route, req).await).await
+        parse_response(fetch!(http, route, req).await).await
     }
 
     /// Revokes an existing api key.
@@ -66,11 +71,18 @@ impl KeyService {
     /// - `req`: The request to send.
     ///
     /// # Returns
-    /// A wrapper around an empty response, or an [`HttpError`].
-    pub async fn revoke_key(&self, http: &HttpService, req: RevokeKeyRequest) -> Wrapped<()> {
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
+    pub async fn revoke_key(
+        &self,
+        http: &HttpService,
+        req: RevokeKeyRequest,
+    ) -> Result<(), HttpError> {
         let route = routes::REVOKE_KEY.compile();
 
-        wrap_empty_response(fetch!(http, route, req).await).await
+        parse_empty_response(fetch!(http, route, req).await).await
     }
 
     /// Updates an existing api key.
@@ -80,11 +92,18 @@ impl KeyService {
     /// - `req`: The request to send.
     ///
     /// # Returns
-    /// A wrapper around an empty response, or an [`HttpError`].
-    pub async fn update_key(&self, http: &HttpService, req: UpdateKeyRequest) -> Wrapped<()> {
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
+    pub async fn update_key(
+        &self,
+        http: &HttpService,
+        req: UpdateKeyRequest,
+    ) -> Result<(), HttpError> {
         let route = routes::UPDATE_KEY.compile();
 
-        wrap_empty_response(fetch!(http, route, req).await).await
+        parse_empty_response(fetch!(http, route, req).await).await
     }
 
     /// Gets details about an api key.
@@ -94,12 +113,19 @@ impl KeyService {
     /// - `req`: The request to send.
     ///
     /// # Returns
-    /// A wrapper around the response, or an [`HttpError`].
-    pub async fn get_key(&self, http: &HttpService, req: GetKeyRequest) -> Wrapped<ApiKey> {
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
+    pub async fn get_key(
+        &self,
+        http: &HttpService,
+        req: GetKeyRequest,
+    ) -> Result<ApiKey, HttpError> {
         let mut route = routes::GET_KEY.compile();
         route.query_insert("keyId", &req.key_id);
 
-        wrap_response(fetch!(http, route).await).await
+        parse_response(fetch!(http, route).await).await
     }
 
     /// Updates the remaining verifications for a key.
@@ -109,14 +135,17 @@ impl KeyService {
     /// - `req`: The request to send.
     ///
     /// # Returns
-    /// A wrapper around the response, or an [`HttpError`].
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
     pub async fn update_remaining(
         &self,
         http: &HttpService,
         req: UpdateRemainingRequest,
-    ) -> Wrapped<UpdateRemainingResponse> {
+    ) -> Result<UpdateRemainingResponse, HttpError> {
         let route = routes::UPDATE_REMAINING.compile();
 
-        wrap_response(fetch!(http, route, req).await).await
+        parse_response(fetch!(http, route, req).await).await
     }
 }


### PR DESCRIPTION
## Summary

Implements `From<Wrapped<T>>` for `Result<T, HttpError>`.
Returns `Result<T, HttpError>` from all service methods, and async client methods.
`Wrapped` is now internal implementation detail.

## Checklist

- [x] I have run `cargo test` and all tests pass.
- [x] I have run `cargo fmt` and the code is formatted.
- [x] I have run `cargo clippy` in pedantic mode and refactored.
- [x] I have included documentation for any new structs or methods.
- [x] I have updated tests for any code I addded/changed/deleted.
- [x] I have updated the CHANGELOG to include my changes.

## Related Issues

Resolves #37 
