### PR TITLE
fix: add key name to `ApiKey`

### DIFF
--- a/src/models/keys.rs
+++ b/src/models/keys.rs
@@ -418,6 +418,9 @@ pub struct ApiKey {
     /// The unique id of this key.
     pub id: String,
 
+    /// The optional name for the key.
+    pub name: Option<String>,
+
     /// The id of the api this key belongs to.
     pub api_id: String,
 


### PR DESCRIPTION
## Summary

Adds the `name` field to the `ApiKey` struct so that it is deserialized from the json result of `get_key` and `list_keys`.

## Checklist

- [X] I have run `cargo test` and all tests pass.
- [X] I have run `cargo fmt` and the code is formatted.
- [X] I have run `cargo clippy` in pedantic mode and refactored.
- [X] I have included documentation for any new structs or methods.
- [X] I have updated tests for any code I addded/changed/deleted.
- [ ] I have updated the CHANGELOG to include my changes.

## Related Issues

<!-- e.g. `Fixes #1` or `Closes #5` -->
