### PR TITLE
Feature [#35]: Add support for delete api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.6.0 (Dec 2024)
+
+## Additions
+
+- Add `delete_api` method to `ApiService` and corresponding `Route`.
+- Add models supporting `delete_api` method.
+
+---
+
 # v0.5.0 (Oct 2024)
 
 ## Additions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "unkey"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "lazy_static",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "unkey"
 description = "An asynchronous Rust SDK for the Unkey API."
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Jonxslays"]
 readme = "README.md"

--- a/src/client.rs
+++ b/src/client.rs
@@ -273,7 +273,7 @@ impl Client {
     /// # async fn delete() {
     /// # use unkey::Client;
     /// # use unkey::models::DeleteApiRequest;
-    /// let c = Client
+    /// let c = Client::new("abc123");
     /// let req = DeleteApiRequest::new("api_id");
     ///
     /// match c.delete_api(req).await {
@@ -282,7 +282,7 @@ impl Client {
     /// }
     /// # }
     /// ````
-    pub async fn delete_api(&self, req: DeleteApiRequest) -> Result<DeleteApiRequest, HttpError> {
+    pub async fn delete_api(&self, req: DeleteApiRequest) -> Result<(), HttpError> {
         self.apis.delete_api(&self.http, req).await
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,7 @@
 use crate::models::ApiKey;
 use crate::models::CreateKeyRequest;
 use crate::models::CreateKeyResponse;
+use crate::models::DeleteApiRequest;
 use crate::models::GetApiRequest;
 use crate::models::GetApiResponse;
 use crate::models::GetKeyRequest;
@@ -253,6 +254,36 @@ impl Client {
     /// ````
     pub async fn get_api(&self, req: GetApiRequest) -> Result<GetApiResponse, HttpError> {
         self.apis.get_api(&self.http, req).await
+    }
+
+    /// Permanently deletes an api and revokes all keys associated with it.
+    ///
+    /// # Arguments
+    ///
+    /// - `req`: The delete api request to send.
+    ///
+    /// # Returns
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # async fn delete() {
+    /// # use unkey::Client;
+    /// # use unkey::models::DeleteApiRequest;
+    /// let c = Client
+    /// let req = DeleteApiRequest::new("api_id");
+    ///
+    /// match c.delete_api(req).await {
+    ///    Ok(res) => println!("{:?}", res),
+    ///    Err(err) => println!("{:?}", err),
+    /// }
+    /// # }
+    /// ````
+    pub async fn delete_api(&self, req: DeleteApiRequest) -> Result<DeleteApiRequest, HttpError> {
+        self.apis.delete_api(&self.http, req).await
     }
 
     /// Retrieves information for the given api id.

--- a/src/client.rs
+++ b/src/client.rs
@@ -259,7 +259,6 @@ impl Client {
     /// Permanently deletes an api and revokes all keys associated with it.
     ///
     /// # Arguments
-    ///
     /// - `req`: The delete api request to send.
     ///
     /// # Returns

--- a/src/models/apis.rs
+++ b/src/models/apis.rs
@@ -198,7 +198,7 @@ pub struct GetApiResponse {
     pub workspace_id: String,
 }
 
-/// An outgoing request to delete an API
+/// An outgoing request to delete an API.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeleteApiRequest {

--- a/src/models/apis.rs
+++ b/src/models/apis.rs
@@ -199,9 +199,33 @@ pub struct GetApiResponse {
 }
 
 /// An outgoing request to delete an API
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeleteApiRequest {
     // The id of the api to delete.
     pub api_id: String,
+}
+
+impl DeleteApiRequest {
+    /// Creates a new delete api request.
+    ///
+    /// # Arguments
+    /// - `api_id`: The id of the api to delete.
+    ///
+    /// # Returns
+    /// The new delete api request.
+    ///
+    /// # Example
+    /// ```
+    /// # use unkey::models::DeleteApiRequest;
+    /// let r = DeleteApiRequest::new("test");
+    ///
+    /// assert_eq!(r.api_id, String::from("test"));
+    /// ```
+    #[must_use]
+    pub fn new<T: Into<String>>(api_id: T) -> Self {
+        Self {
+            api_id: api_id.into(),
+        }
+    }
 }

--- a/src/models/apis.rs
+++ b/src/models/apis.rs
@@ -197,3 +197,11 @@ pub struct GetApiResponse {
     #[serde(rename = "workspaceId")]
     pub workspace_id: String,
 }
+
+/// An outgoing request to delete an API
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteApiRequest {
+    // The id of the api to delete.
+    pub api_id: String,
+}

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -30,6 +30,9 @@ pub(crate) static GET_API: Route = Route::new(Method::GET, "/apis.getApi");
 /// The list keys endpoint `GET /apis.listKeys`
 pub(crate) static LIST_KEYS: Route = Route::new(Method::GET, "/apis.listKeys");
 
+/// The delete api endpoint `POST /apis.deleteApi`
+pub(crate) static DELETE_API: Route = Route::new(Method::POST, "/apis.deleteApi");
+
 ////////////////////////////////////////////////////////////////////////////////
 // END ROUTES
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/services/apis.rs
+++ b/src/services/apis.rs
@@ -4,6 +4,7 @@ use crate::models::GetApiRequest;
 use crate::models::GetApiResponse;
 use crate::models::ListKeysRequest;
 use crate::models::ListKeysResponse;
+use crate::parse_empty_response;
 use crate::parse_response;
 use crate::routes;
 use crate::services::HttpService;
@@ -89,10 +90,10 @@ impl ApiService {
         &self,
         http: &HttpService,
         req: DeleteApiRequest,
-    ) -> Result<DeleteApiRequest, HttpError> {
+    ) -> Result<(), HttpError> {
         let mut route = routes::DELETE_API.compile();
         route.query_insert("apiId", &req.api_id);
 
-        parse_response(fetch!(http, route).await).await
+        parse_empty_response(fetch!(http, route).await).await
     }
 }

--- a/src/services/apis.rs
+++ b/src/services/apis.rs
@@ -75,7 +75,7 @@ impl ApiService {
         parse_response(fetch!(http, route).await).await
     }
 
-    /// Permanently delete an API and revoke all keys associated with it
+    /// Permanently delete an API and revoke all keys associated with it.
     ///
     /// # Arguments
     /// - `http`: The http service to use for the request.
@@ -91,9 +91,8 @@ impl ApiService {
         http: &HttpService,
         req: DeleteApiRequest,
     ) -> Result<(), HttpError> {
-        let mut route = routes::DELETE_API.compile();
-        route.query_insert("apiId", &req.api_id);
+        let route = routes::DELETE_API.compile();
 
-        parse_empty_response(fetch!(http, route).await).await
+        parse_empty_response(fetch!(http, route, req).await).await
     }
 }

--- a/src/services/apis.rs
+++ b/src/services/apis.rs
@@ -1,4 +1,5 @@
 use crate::fetch;
+use crate::models::DeleteApiRequest;
 use crate::models::GetApiRequest;
 use crate::models::GetApiResponse;
 use crate::models::ListKeysRequest;
@@ -68,6 +69,28 @@ impl ApiService {
         req: GetApiRequest,
     ) -> Result<GetApiResponse, HttpError> {
         let mut route = routes::GET_API.compile();
+        route.query_insert("apiId", &req.api_id);
+
+        parse_response(fetch!(http, route).await).await
+    }
+
+    /// Permanently delete an API and revoke all keys associated with it
+    ///
+    /// # Arguments
+    /// - `http`: The http service to use for the request.
+    /// - `req`: The request to send.
+    ///
+    /// # Returns
+    /// A [`Result`] containing the response, or an error.
+    ///
+    /// # Errors
+    /// The [`HttpError`], if one occurred.
+    pub async fn delete_api(
+        &self,
+        http: &HttpService,
+        req: DeleteApiRequest,
+    ) -> Result<DeleteApiRequest, HttpError> {
+        let mut route = routes::DELETE_API.compile();
         route.query_insert("apiId", &req.api_id);
 
         parse_response(fetch!(http, route).await).await


### PR DESCRIPTION
## Summary

<!-- A small summary of the requested changes -->

- Added delete_api method to the ApiService, enabling users to remove APIs programmatically.
- Integrated a new Route to support the delete_api method for seamless API deletion.
- Introduced supporting models required for the delete_api functionality.

## Checklist

<!--
- [x] Correct
- [X] Correct
-->

- [x] I have run `cargo test` and all tests pass.
- [x] I have run `cargo fmt` and the code is formatted.
- [x] I have run `cargo clippy` in pedantic mode and refactored.
- [x] I have included documentation for any new structs or methods.
- [x] I have updated tests for any code I addded/changed/deleted.
- [x] I have updated the CHANGELOG to include my changes.

## Related Issues

<!-- e.g. `Fixes #1` or `Closes #5` -->
